### PR TITLE
use kbd class that can be printed human understandable format and rea…

### DIFF
--- a/keymap.lisp
+++ b/keymap.lisp
@@ -32,6 +32,8 @@
 (defvar *global-keymap* (make-keymap "global" 'undefined-key))
 
 (defun define-key (keymap key cmd-name)
+  (when (typep key 'kbd)
+    (setq key (slot-value key 'list)))
   (unless (and (listp key)
                (dolist (k key t)
                  (unless (characterp k)
@@ -44,39 +46,49 @@
   (apply 'concatenate 'string
          (mapcar (lambda (c)
                    (cond
-                    ((key::ctrl-p c)
-                     (format nil "C-~c"
-                             (char-downcase
-                              (code-char
-                               (+ 64 (char-code c))))))
-                    ((char= c key::escape)
-                     "M-")
-                    (t
-                     (string c))))
+                     ((key::ctrl-p c)
+                      (format nil "C-~c"
+                              (char-downcase
+                               (code-char
+                                (+ 64 (char-code c))))))
+                     ((char= c key::escape)
+                      "M-")
+                     (t
+                      (string c))))
                  key)))
 
+(defclass kbd ()
+  ((list :initarg :list)))
+
+(defmethod print-object ((k kbd) stream)
+  (format stream "(~A ~S)" 'kbd (kbd-to-string (slot-value k 'list))))
+
 (defun kbd (str)
-  (let ((i 0)
-        (key))
-    (do ((i 0 (1+ i)))
-        ((>= i (length str)))
-      (case (aref str i)
-        (#\C
-         (assert (char= #\- (aref str (incf i))))
-         (push (code-char
-                (- (char-code
-                    (char-upcase
-                     (aref str (incf i))))
-                   64))
-               key))
-        (#\M
-         (assert (char= #\- (aref str (incf i))))
-         (push key::escape key))
-        (t
-         (push (aref str i) key))))
-    (nreverse key)))
+  (make-instance
+   'kbd
+   :list (let ((i 0)
+               (key))
+           (do ((i 0 (1+ i)))
+               ((>= i (length str)))
+             (case (aref str i)
+               (#\C
+                (assert (char= #\- (aref str (incf i))))
+                (push (code-char
+                       (- (char-code
+                           (char-upcase
+                            (aref str (incf i))))
+                          64))
+                      key))
+               (#\M
+                (assert (char= #\- (aref str (incf i))))
+                (push key::escape key))
+               (t
+                (push (aref str i) key))))
+           (nreverse key))))
 
 (defun keymap-find-command (keymap key)
+  (when (typep key 'kbd)
+    (setq key (slot-value key 'list)))
   (let ((cmd (gethash key (keymap-table keymap))))
     (or cmd
         (let ((keymap (keymap-parent keymap)))
@@ -94,10 +106,14 @@
     acc))
 
 (defun key-undef-hook (keymap key)
+  (when (typep key 'kbd)
+    (setq key (slot-value key 'list)))
   (when (keymap-undef-hook keymap)
     (funcall (keymap-undef-hook keymap) key)))
 
 (defun insertion-key-p (key)
+  (when (typep key 'kbd)
+    (setq key (slot-value key 'list)))
   (when (or (< 31 (char-code (car key)))
             (char= key::ctrl-i (car key)))
     (car key)))


### PR DESCRIPTION
kbd関数からの戻り値が、読みにくかったので(kbd 文字列)のカタチで帰ってくるようにしました。
付随してkbd関数の返り値を受ける関数に型を確認してlistに戻す処理を追加。
この形式が正規という事ならwhenはとった方が良いと思います。

こっちの方が絶対良いってほどでもない、ただの思い付きなので
「どうでしょう?」的な。
オブジェクト同士の同値性のチェックとかでハマる人がでるパターンとかが懸念です。