### PR TITLE
Wmhen key to define-key function was string or list convert it to kbd…

### DIFF
--- a/keymap.lisp
+++ b/keymap.lisp
@@ -53,11 +53,15 @@
   (typep x 'kbd))
 
 (defun define-key (keymap key cmd-name)
-  (unless (and (kbd-p key)
-               (every #'characterp (kbd-list key)))
-    (error "define-key: ~s is illegal key" key))
-  (setf (gethash key (keymap-table keymap))
-        cmd-name))
+  (let ((kbd (typecase key
+               (list (apply #'kbd key))
+               (string (kbd key))
+               (t key))))
+    (unless (and (kbd-p kbd)
+                 (every #'characterp (kbd-list kbd)))
+      (error "define-key: ~s is illegal key" key))
+    (setf (gethash kbd (keymap-table keymap))
+          cmd-name)))
 
 (defun kbd-to-string (key)
   (format nil "~{~A~^~}"


### PR DESCRIPTION
常に(kbd)は冗長だなと思いまして、define-keyは文字列かリストで渡せるようにしました。
kbdがちょっと良い名前だと思えないというのもあります。
また別の大きな変更の話で別途issueにすべきかと思いますが、
文字とは別にキーオブジェクトを作ったらいかがかと思っています。
例えば、#/C-x #/C-M-x 等々があると、移植を考えた時には便利かと。
