### PR TITLE
ros installでの簡単セットアップ

### DIFF
--- a/roswell/lem.ros
+++ b/roswell/lem.ros
@@ -1,0 +1,38 @@
+#!/bin/sh
+#|-*- mode:lisp -*-|#
+#| lem simple emacs clone.
+exec ros -Q -m roswell -L sbcl-bin -- $0 "$@"
+|#
+(progn
+  (unless (find-package :lem)
+    (ql:quickload :lem)))
+
+(defpackage :ros.script.lem.3672618460
+  (:use :cl))
+(in-package :ros.script.lem.3672618460)
+
+(defun usage ()
+  (format t "~{~A~%~}" `(,(format nil "usage: ~A [OPTION]... [FILE]..." (ros:opt "wargv0"))
+                         "-d --debug"
+                         "-h --help")))
+
+(defun main (&rest argv)
+  (let ((debug-flag)
+        (filenames))
+    (loop for arg- on argv
+          for arg = (first arg-)
+          do (cond ((or (string= "--debug" arg)
+                        (string= "-d" arg))
+                    (setq debug-flag t))
+                   ((or (string= "--help" arg)
+                        (string= "-h" arg))
+                    (usage)
+                    (return-from main))
+                   (t
+                    (push arg filenames))))
+    (setq filenames (nreverse filenames))
+    (if debug-flag
+        (let ((lem::*program-name* "lem dbg"))
+          (apply #'lem:lem filenames))
+        (apply #'lem:lem filenames))))
+;;; vim: set ft=lisp lisp:


### PR DESCRIPTION
roswellが入っている前提でのlemのセットアップ(lemだけの事を考えているわけではないのですが…)を少し便利にしました。

roswellのバージョン
```
% ros --version
roswell 0.0.6.62(22c0787)  #0.0.6.62以前のリリースだと動きません。
```

セットアップ
```
% ros install snmsts/lem # githubの内容をgitでチェックアウトします。
% rm ~/.roswell/local-projects/system-index.txt  # これが必要なのは現状のroswellのバグです。調査してroswellの方を直します
% ros install lem # lemのroswellディレクトリの中身を~/.roswell/bin/以下にコピーします。
% ros setup # ~/.roswell/lemの利用dumpがroswellになっているのでlemを含めたdumpを生成します。
```

```
% ~/.roswell/lem
```
もうすこしセットアップの手数を減らすつもりですが(``ros install snmsts/lem``だけとか)、スクリプト自体の仕様はかえずに動くようにするので、邪魔に感じなければ取り込んでいただけると嬉しいです。
