### PR TITLE
Roswellで使用中の処理系で実行するように変更しました

### DIFF
--- a/roswell/lem.ros
+++ b/roswell/lem.ros
@@ -1,7 +1,7 @@
 #!/bin/sh
 #|-*- mode:lisp -*-|#
 #| lem simple emacs clone.
-exec ros -Q -- $0 "$@"
+exec ros -Q -m roswell -- $0 "$@"
 |#
 (progn
   (unless (find-package :lem)

--- a/roswell/lem.ros
+++ b/roswell/lem.ros
@@ -1,7 +1,7 @@
 #!/bin/sh
 #|-*- mode:lisp -*-|#
 #| lem simple emacs clone.
-exec ros -Q -m roswell -L sbcl-bin -- $0 "$@"
+exec ros -Q -- $0 "$@"
 |#
 (progn
   (unless (find-package :lem)


### PR DESCRIPTION
`ros use ccl-bin`等でsbclでない処理系を利用していてもsbcl-bin限定で動作していました．
もしあえてsbclに限定しているのでなければ処理系の指定は外していただけるとありがたいです．

現在 `ros init`した時に出力される内容に書き換えています．

(sbclだと動かない環境があり，cclで`(prongn (ql:quickload 'lem) (lem:lem))`だと動いたので，
この修正によりroswellスクリプトとしても動くようになりました)