### PR TITLE
separate from roswell's image file.

### DIFF
--- a/roswell/lem.ros
+++ b/roswell/lem.ros
@@ -1,7 +1,7 @@
 #!/bin/sh
 #|-*- mode:lisp -*-|#
 #| lem simple emacs clone.
-exec ros -Q -m roswell -L sbcl-bin -- $0 "$@"
+exec ros -Q -m lem -L sbcl-bin -- $0 "$@"
 |#
 (progn
   (unless (find-package :lem)


### PR DESCRIPTION
sorry my decision was not good.
I notice sharing same image name cause slow down when making image file and affected by broken each other.

稀にlemのパッケージ変更の為にroswellの開発中のイメージダンプに失敗したりしました。
あとlemに一切変更していなくてもload→dumpまでの時間が余計にかかるので、
分離した方が良いかな…と思いました。ディスク容量で少し損する以外はとりたててダメージは無いかと思いますので問題なさそうであれば宜しく願います。
