### PR TITLE
load `~/.lem/site-init.lisp` before dump core.

### DIFF
--- a/lem-core/init.lisp
+++ b/lem-core/init.lisp
@@ -6,10 +6,10 @@
 	     (load path)
 	     (message "Load file: ~a" path)
 	     t)))
-    (or (test (merge-pathnames "lem.rc" (truename ".")))
-        (test (merge-pathnames ".lemrc" (user-homedir-pathname))))))
-
-(add-hook *after-init-hook* 'load-init-file)
+    (let ((home (user-homedir-pathname)))
+      (or (ignore-errors (test (merge-pathnames "lem.rc" (truename "."))))
+          (test (merge-pathnames ".lem/init.lisp" home))
+          (test (merge-pathnames ".lemrc" home))))))
 
 #+sbcl
 (push #'(lambda (x)

--- a/lem-core/lem.lisp
+++ b/lem-core/lem.lisp
@@ -4,6 +4,8 @@
           with-editor
           lem))
 
+(defvar *before-init-hook* '())
+
 (defvar *after-init-hook* '())
 
 (defvar *in-the-editor* nil)
@@ -93,11 +95,19 @@
 (defmacro with-editor (() &body body)
   `(call-with-editor (lambda () ,@body)))
 
+(defun parse-args (args)
+  ;; stub
+  (mapcar (lambda (file) `(find-file ,file)) args))
+
 (defun lem (&rest args)
+  (setf args (parse-args args))
   (if *in-the-editor*
-      (mapc 'find-file args)
-      (with-editor ()
-        (lem-internal
-         (lambda ()
-           (run-hooks *after-init-hook*)
-           (mapc 'find-file args))))))
+      (loop for exp in args do (eval exp))
+      (progn
+        (run-hooks *before-init-hook*)
+        (with-editor ()
+          (lem-internal
+           (lambda ()
+             (load-init-file) ;; need to idea for support '-q' '-u' on emacs
+             (run-hooks *after-init-hook*)
+             (loop for exp in args do (eval exp))))))))

--- a/roswell/lem.ros
+++ b/roswell/lem.ros
@@ -5,7 +5,10 @@ exec ros -Q -m lem -L sbcl-bin -- $0 "$@"
 |#
 (progn
   (unless (find-package :lem)
-    (ql:quickload :lem)))
+    (ql:quickload :lem))
+  ;; It should be part of lem. but I can't place where's apropriate. (2017/05/12 SANO)
+  (load (merge-pathnames ".lem/site-init.lisp" (user-homedir-pathname))
+        :if-does-not-exist nil))
 
 (defpackage :ros.script.lem.3672618460
   (:use :cl))


### PR DESCRIPTION
~/.lemrcに

```
;;-*- mode:lisp -*-                                                                                                                                                                           
(ql:quickload :swank :silent t)
(swank:create-server :dont-close t)
```

としているのですが、起動は遅いしstderrorに出力が出てきて最初から画面が崩れるしで良いこと無いので、
lemのdump時にユーザが追加のコードをloadできるようにすることと、
lemの起動時にwindowの類を初期化する前にコードの実行ができるように少し考えました。
マージ後の整理は必要かと思いますが、どうかよろしくお願いします。

あと混じってしまいましたが``(truename ".")`` はpwdが削除済みの場合エラーをおこします。