### PR TITLE
describe-bindings not show 'undeined-key' and downcase function name.

### DIFF
--- a/lem-core/help-command.lisp
+++ b/lem-core/help-command.lisp
@@ -26,10 +26,11 @@
     (format s "~va~a~%" column-width "---" "-------")
     (keymap-flatten-map keymap
                         (lambda (kbd command)
-                          (format s "~va~a~%"
-                                  column-width
-                                  (kbd-to-string kbd)
-                                  (symbol-name command))))
+                          (unless (equal "UNDEFINED-KEY" (symbol-name command))
+                            (format s "~va~(~a~)~%"
+                                    column-width
+                                    (kbd-to-string kbd)
+                                    (symbol-name command)))))
     (terpri s)))
 
 (define-command describe-bindings () ()


### PR DESCRIPTION
小文字にするのは趣味ですが、undefined-keyの非表示は万人が嬉しいかと思います。