### PR TITLE
define-command changed not to return gensymd symbol

### DIFF
--- a/lem-core/defcommand.lisp
+++ b/lem-core/defcommand.lisp
@@ -96,7 +96,8 @@
                       *command-table*)
              ',gcmd)
        (defun ,name ,parms ,@body)
-       ,(define-command-gen-cmd gcmd name parms arg-descripters))))
+       ,(define-command-gen-cmd gcmd name parms arg-descripters)
+       ',name)))
 
 (defun all-command-names ()
   (let ((names))


### PR DESCRIPTION
quite trivial.