### PR TITLE
Dired cannot list files in path that has space(s)

### DIFF
--- a/lem-core/command.lisp
+++ b/lem-core/command.lisp
@@ -474,7 +474,7 @@
                   (with-input-from-string (input string)
                     (multiple-value-setq
                         (output-value error-output-value status)
-                      (uiop:run-program (format nil "cd ~A; ~A" (buffer-directory buffer) cmd)
+                      (uiop:run-program (format nil "cd '~A'; ~A" (buffer-directory buffer) cmd)
                                         :input input
                                         :output output
                                         :error-output output
@@ -490,7 +490,7 @@
   (let ((directory (buffer-directory)))
     (let ((output-string
             (with-output-to-string (out)
-              (uiop:run-program (format nil "cd ~A; ~A" directory str)
+              (uiop:run-program (format nil "cd '~A'; ~A" directory str)
                                 :output out
                                 :error-output out
                                 :ignore-error-status t))))

--- a/lem-core/dired.lisp
+++ b/lem-core/dired.lisp
@@ -291,7 +291,7 @@
 
 (defun ls-output-string (filename)
   (with-output-to-string (stream)
-    (uiop:run-program (format nil "LANG=en; ls -al ~A" filename) :output stream)))
+    (uiop:run-program (format nil "LANG=en; ls -al '~A'" filename) :output stream)))
 
 (defun update (buffer)
   (with-buffer-read-only buffer nil

--- a/lem-core/grep.lisp
+++ b/lem-core/grep.lisp
@@ -79,7 +79,7 @@
                (call-background-job
                 (lambda ()
                   (with-output-to-string (s)
-                    (uiop:run-program (format nil "cd ~A; ~A" directory string)
+                    (Uiop:run-program (format nil "cd '~A'; ~A" directory string)
                                       :output s
                                       :error-output s
                                       :ignore-error-status t)))

--- a/lem-core/gtags.lisp
+++ b/lem-core/gtags.lisp
@@ -46,7 +46,7 @@
 
 (defun global (directory &rest args)
   (with-output-to-string (out)
-    (uiop:run-program (format nil "cd ~A; global ~{'~A'~^ ~}" directory args)
+    (uiop:run-program (format nil "cd '~A'; global ~{'~A'~^ ~}" directory args)
                       :output out
                       :ignore-error-status t)))
 

--- a/lem-go-mode/go-mode.lisp
+++ b/lem-go-mode/go-mode.lisp
@@ -300,7 +300,7 @@
          (let ((text
                  (with-output-to-string (out)
                    (uiop:run-program
-                    (format nil "cd ~A; goflymake -debug=false '~A'"
+                    (format nil "cd '~A'; goflymake -debug=false '~A'"
                             directory
                             flymake-file)
                     :output out

--- a/test/lisp-indent.ros
+++ b/test/lisp-indent.ros
@@ -28,7 +28,7 @@ exec ros -Q -- $0 "$@"
     (indent-file tempfile)
     (let ((text
             (with-output-to-string (output)
-              (uiop:run-program (format nil "diff ~A ~A" file tempfile)
+              (uiop:run-program (format nil "diff '~A' '~A'" file tempfile)
                                 :output output
                                 :error-output output
                                 :ignore-error-status t))))


### PR DESCRIPTION
Hi. I found a dired's bug and fixed it.

## How to reproduce

1. make directory such that the path string has space(s)
2. `find-file` with the path above

## Error messages

- `find-file` with `/path/to/space included/dir/`

```
Subprocess with command "LANG=en; ls -al /path/to/space included/dir/"
Backtrace for: #<SB-THREAD:THREAD "editor" RUNNING {1002ECF3E3}>
0: ((LAMBDA NIL :IN UIOP/IMAGE:PRINT-BACKTRACE))
1: ((FLET "THUNK" :IN UIOP/STREAM:CALL-WITH-SAFE-IO-SYNTAX))
...
7: (CERROR "IGNORE-ERROR-STATUS" UIOP/RUN-PROGRAM:SUBPROCESS-ERROR :COMMAND "LANG=en; ls -al /path/to/space included/dir/" :CODE 2 :PROCESS NIL)
...
```

## Similar points

I think that some lines of these has same probrem about path quotation...🤔
At second commit, I fixed part of these.

```
~/code/lem$ git grep run-program
lem-core/command.lisp:                      (uiop:run-program (format nil "cd ~A; ~A" (buffer-directory buffer) cmd)
lem-core/command.lisp:              (uiop:run-program (format nil "cd ~A; ~A" directory str)
lem-core/dired.lisp:            (uiop:run-program (apply #'format nil string args)
lem-core/dired.lisp:    (uiop:run-program (format nil "LANG=en; ls -al '~A'" filename) :output stream)))
lem-core/grep.lisp:                    (uiop:run-program (format nil "cd ~A; ~A" directory string)
lem-core/gtags.lisp:    (uiop:run-program (format nil "cd ~A; global ~{'~A'~^ ~}" directory args)
lem-core/gtags.lisp:     (uiop:run-program "global -p"
lem-go-mode/go-mode.lisp:            (uiop:run-program (concatenate 'string "godoc " command)
lem-go-mode/go-mode.lisp:                (uiop:run-program (format nil
lem-go-mode/go-mode.lisp:                (uiop:run-program (format nil "gocode -f=json autocomplete '~A' c~D"
lem-go-mode/go-mode.lisp:                   (uiop:run-program
lem-lisp-mode/lisp-mode.lisp:  (uiop:run-program (format nil "ros ~{~S~^ ~} &"
test/lisp-indent.ros:              (uiop:run-program (format nil "diff ~A ~A" file tempfile)
```