### PR TITLE
npm installable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ DEBUG
 *.so
 *.fasl
 roswell/lem
+node_modules
+package-lock.json

--- a/lem-frontend-electron/.gitignore
+++ b/lem-frontend-electron/.gitignore
@@ -1,2 +1,0 @@
-node_modules
-package-lock.json

--- a/lem-frontend-electron/cli.js
+++ b/lem-frontend-electron/cli.js
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+const spawn = require('child_process').spawn;
+const electron = require('electron');
+const argv = [ __dirname ];
+spawn(electron, argv, { stdio: 'inherit' });

--- a/lem-frontend-electron/package.json
+++ b/lem-frontend-electron/package.json
@@ -14,5 +14,6 @@
     "marked": "^0.3.6",
     "utf-8": "^1.0.0",
     "vscode-jsonrpc": "^3.4.1"
-  }
+  },
+  "bin": "cli.js"
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "lem",
   "version": "1.0.0",
   "description": "lem frontend",
-  "main": "index.js",
+  "main": "lem-frontend-electron/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
@@ -15,5 +15,5 @@
     "utf-8": "^1.0.0",
     "vscode-jsonrpc": "^3.4.1"
   },
-  "bin": "cli.js"
+  "bin": "lem-frontend-electron/cli.js"
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "lem frontend",
   "main": "lem-frontend-electron/index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "preinstall": "ros install cxxxr/lem"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
Hi, there. This request is **not complete** but it currently works like this.

```
$ npm insall -g asciian/lem#npm-installable
```

If you merged, we can do this on your repository `npm install -g cxxxr/lem`.

These command will install a binary of frontend-electron as /usr/local/bin/lem.
When we type `lem`, shell calls `~/.roswell/bin/lem` before `/usr/local/bin/lem`.
So, now, we cannot  use `/usr/local/bin/lem`. To solve this issue,  you should change the name of frontend-electron. I propose these nickname, `lemon` and `golem`.

Thanks!

