### PR TITLE
describe-bindings-internal crashed on null keymap.

### DIFF
--- a/lem-core/help-command.lisp
+++ b/lem-core/help-command.lisp
@@ -24,13 +24,14 @@
     (terpri s)
     (format s "~va~a~%" column-width "key" "binding")
     (format s "~va~a~%" column-width "---" "-------")
-    (keymap-flatten-map keymap
-                        (lambda (keys command)
-                          (unless (equal "UNDEFINED-KEY" (symbol-name command))
-                            (format s "~va~(~a~)~%"
-                                    column-width
-                                    (keyseq-to-string keys)
-                                    (symbol-name command)))))
+    (when keymap
+      (keymap-flatten-map keymap
+                          (lambda (keys command)
+                            (unless (equal "UNDEFINED-KEY" (symbol-name command))
+                              (format s "~va~(~a~)~%"
+                                      column-width
+                                      (keyseq-to-string keys)
+                                      (symbol-name command))))))
     (terpri s)))
 
 (define-command describe-bindings () ()


### PR DESCRIPTION
This happens in the initial tmp buffer, making `describe-bindings` crash.  A simple check prints null bindings without flattening the null keymap.