### PR TITLE
XCB refactoring and cleanup; thread-safe.

### DIFF
--- a/lem-frontend-xcb/global.lisp
+++ b/lem-frontend-xcb/global.lisp
@@ -1,7 +1,8 @@
 (in-package :xcb)
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
-  (defparameter *xbug* nil)
+  (defparameter *compile-checked* t)
+  (defparameter *xbug* t)
   (defparameter *q* *standard-output*)
   (defparameter *show-unhandled-events* nil))
 
@@ -11,8 +12,6 @@
        (format *q* "xcb:" )
        (format *q* ,@rest))))
 
-(eval-when (:compile-toplevel :load-toplevel :execute)
-  (defparameter *compile-checked* nil))
 
 ;; Compile a checked version of the function form.
 (defmacro check (function-form &key message)

--- a/lem-frontend-xcb/global.lisp
+++ b/lem-frontend-xcb/global.lisp
@@ -1,8 +1,8 @@
 (in-package :xcb)
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
-  (defparameter *compile-checked* t)
-  (defparameter *xbug* t)
+  (defparameter *compile-checked* nil)
+  (defparameter *xbug* nil)
   (defparameter *q* *standard-output*)
   (defparameter *show-unhandled-events* nil))
 

--- a/lem-frontend-xcb/lem-xcb.asd
+++ b/lem-frontend-xcb/lem-xcb.asd
@@ -13,8 +13,9 @@
 	       (:file "xcb-app/ft2")
 	       (:file "xcb-app/event-handling")
 	       (:file "xcb-app/xcb-system")
+	       (:file "xcb-app/window-direct")
+	       (:file "xcb-app/window-double")
 	       (:file "xcb-app/attributes")
-	       (:file "xcb-app/win")
 	       (:file "xcb-app/geometry")
 	       (:file "xcb-app/lemwin")
 	 

--- a/lem-frontend-xcb/xcb-app/ft2.lisp
+++ b/lem-frontend-xcb/xcb-app/ft2.lisp
@@ -16,7 +16,8 @@
 
 (defun ft2init ()
     (let ((result  (set-lcd-filter& ft2::*library* 1)))
-      (format t "filter set; resultd ~A~&" result)))
+;      (format t "filter set; resultd ~A~&" result)
+      ))
 
 (defclass font ()
   ((face :accessor face :initform nil)

--- a/lem-frontend-xcb/xcb-app/geometry.lisp
+++ b/lem-frontend-xcb/xcb-app/geometry.lisp
@@ -5,6 +5,7 @@
    (cell-width  :accessor cell-width  :initform 7)
    (cell-baseline :accessor cell-baseline :initform 11)))
 
+
 (defun cell-rect (geo col row &optional (columns 1) (rows 1))
   "return x y w h for a cell or a group of cells"
   (with-slots (cell-height cell-width) geo

--- a/lem-frontend-xcb/xcb-app/window-direct.lisp
+++ b/lem-frontend-xcb/xcb-app/window-direct.lisp
@@ -1,0 +1,117 @@
+(in-package :xcb)
+
+
+(defparameter *w* nil)
+
+(defgeneric destroy (win))
+;;-----------------------------------------------------------------------------
+;; win protocol
+(defgeneric win-on-configure-notify (win event x y w h))
+(defgeneric win-on-expose (win event))
+(defgeneric win-on-resize (win w h))
+(defgeneric win-on-key-press (win key state))
+;; simply redraw the window
+(defgeneric win-refresh (win))
+;;=============================================================================
+;; Bufwin is a generic window with an off-screen buffer.
+(defclass window-direct ()
+  ((id  :accessor id :initform nil)  ;; window xcb id
+   (pic :accessor pic :initform nil) ;; draw here picture id
+   (width   :accessor width   :initform 0)
+   (height  :accessor height  :initform 0)
+
+   (pic-lock :accessor pic-lock :initform nil)
+))
+
+(defmethod initialize-instance :after ((win window-direct) &key w h )
+  (setf *w* win)
+  (with-slots (pic-lock width height) win
+    (setf width w
+	  height h)
+    (win-startup win)
+    (setf pic-lock (bt:make-lock))
+    win))
+;;==============================================================================
+;; called by initialize-instance
+(defun win-startup (win)
+  (with-slots (id pic width height) win
+    (setf id (generate-id c) ;; window id
+	  pic (generate-id c)) ;;picture id
+    (with-foreign-slots ((root root-visual white-pixel black-pixel
+			       root-depth) s
+			 (:struct screen-t))
+      (w-foreign-values (vals
+			 ;;:uint32 white-pixel
+			 :uint32 (+
+				  EVENT-MASK-EXPOSURE
+				  EVENT-MASK-STRUCTURE-NOTIFY
+				  ;;EVENT-MASK-RESIZE-REDIRECT
+				  ;; EVENT-MASK-BUTTON-PRESS
+				  EVENT-MASK-KEY-PRESS )) 
+	(check (create-window c root-depth id
+			      root
+			      0 0 width height 10
+			      WINDOW-CLASS-INPUT-OUTPUT
+			      root-visual
+			      (+ CW-EVENT-MASK ;;CW-BACK-PIXEL
+				 ) vals)))
+      ;; windows get registered
+      (window-register id win)
+      ;; screen picture for window
+      (check (create-picture c pic id +RGB24+ 0 (null-pointer)))
+      
+      (map-window c id)
+      ;; ask WM to send us WM_DELETE_WINDOW message on go-away click
+      (w-foreign-values (patom :uint32 +WM-DELETE-WINDOW+)
+	(check (change-property c PROP-MODE-REPLACE id +WM-PROTOCOLS+
+				4 32 1 patom)))
+      (flush c))))
+
+
+
+(defmethod destroy ((win window-direct))
+  (remhash (id win) windows ))
+
+(defparameter *w* nil)
+
+(defun win-set-name (win name)
+  (let ((len (length name))
+	(str (foreign-string-alloc name)))
+    (w-foreign-values (buf :uint32 8)
+      (check (change-property c PROP-MODE-REPLACE (id win) ATOM-WM-NAME
+			      ATOM-STRING 8 len str)))
+    (foreign-free str)))
+
+
+;;==============================================================================
+;; handle resizing
+;;
+;; changed:
+;; x y  w or h = dragging ul
+;; x y         = moving
+;; w or h      = resizing
+
+(defmethod win-on-configure-notify ((win window-direct) e x y w h)
+  (if (or (/= (width win) w)
+	  (/= (height win) h))
+      (progn (win-on-resize win w h)))
+  t)
+
+;;==============================================================================
+;; Synthesized by win-on-configure-notify, not resize event (which we are not
+;; redirecting!)
+;;
+(defmethod win-on-resize ((win window-direct) w h)
+  (with-slots (width height) win
+    (setf width w
+	  height h))
+  t)
+;;------------------------------------------------------------------------------
+(defmethod win-on-expose ((win window-direct) event)
+  (win-refresh win)
+  t)
+;;------------------------------------------------------------------------------
+(defmethod win-refresh ((win window-direct))
+  ;; ostensibly, we finished drawing
+  (xcb::flush c)
+  )

--- a/lem-frontend-xcb/xcb-app/window-double.lisp
+++ b/lem-frontend-xcb/xcb-app/window-double.lisp
@@ -1,0 +1,56 @@
+(in-package :xcb)
+;;
+;; Strategy: Change exposed xcb handle for pic to an offscreen buffer;
+;; refresh will copy to screen.
+;;
+;;=============================================================================
+;; Bufwin is a generic window with an off-screen buffer.
+(defclass window-db (window-direct)
+  ((pix-off :accessor pix-off :initform nil) ;; off-screen pixmap id
+   (pic-screen :accessor pic-screen :initform nil) ;;
+   
+))
+
+;;=============================================================================
+;; After initializing the screen, convert pic to be an offscreen buffer.
+;;
+(defmethod initialize-instance :after ((win  window-db) &key )
+  (with-slots (pic pix-off pic-screen width height) win
+    (setf pic-screen pic); original screen buffer
+     ;; off-screen picture
+    (mvsetq (pic pix-off)
+	(new-offscreen-picture width height))
+    (flush c)
+    win))
+
+
+(defmethod destroy :before ((win window-db))
+  (with-slots (pic pix-off id ) win
+    (check (free-pixmap c pix-off))
+    (check (free-picture c pic))))
+
+
+(defmethod win-refresh ((win window-db))
+  (with-slots (pic pic-screen width height) win
+    (check (composite c OP-SRC pic 0 pic-screen 0 0 0 0 0 0 width height))
+    (flush c)))
+;;==============================================================================
+;; Invoked by win-on-configure-notify, not resize event (which we are not
+;; redirecting!)
+;;
+;; Todo: check if this is thread-safe.  Slowing it down, by debug output,
+;; causes intermittent crashes.  Probably due to thread going to sleep on
+;; output!, so possibly, not an issue.
+(defmethod win-on-resize :after ((win window-db) w h)
+  (with-slots ( pic pic-lock pix-off width height) win
+    ;; allocate a new off-screen picture and pixmap..
+    (bt:with-lock-held (pic-lock)
+      (check (free-pixmap c pix-off))
+      (check (free-picture c pic))
+      (mvsetq (pic pix-off)
+	  (new-offscreen-picture w h))))
+  t)
+;;------------------------------------------------------------------------------
+(defmethod win-on-expose ((win window-db) event)
+  (win-refresh win)
+  t)

--- a/lem-frontend-xcb/xcb-app/xcb-system.lisp
+++ b/lem-frontend-xcb/xcb-app/xcb-system.lisp
@@ -82,7 +82,7 @@
   (event-push-handler EVENT-CONFIGURE-NOTIFY #'on-configure-notify)
 ;;  (event-push-handler EVENT-RESIZE-REQUEST #'on-resize-request)
   (event-push-handler EVENT-DESTROY-NOTIFY #'on-destroy-notify)
-  (event-push-handler EVENT-MAP-NOTIFY #'on-map-notify)
+;;  (event-push-handler EVENT-MAP-NOTIFY #'on-map-notify)
 ;  (setf *styles* (make-instance 'styles))
   )
 ;;------------------------------------------------------------------------------

--- a/lem-frontend-xcb/xcb-app/xcb-system.lisp
+++ b/lem-frontend-xcb/xcb-app/xcb-system.lisp
@@ -147,6 +147,7 @@
     (check (create-pixmap  c 32 pixmap root-window width height))
     (check (create-picture c picture pixmap +ARGB32+ value-mask value-list))
     (pic-rect picture #xFFFF000000000000 0 0 width height)
+    (flush c)
     (values picture pixmap)))
 
 (defun pic-rect (picture color x y width height)


### PR DESCRIPTION
Refactored double-buffer;
Thread-safety features:
During interactive resizing, editor thread occasionally crashed the UI thread by injecting events while pixmaps were being reallocated.  This happened only when debug messages created an opportunity for thread switch - possibly never without, but it's better to be thread-safe than thread-sorry.