### PR TITLE
Font handling still not right, but at least does not crash

### DIFF
--- a/lem-frontend-xcb/xcb-app/ft2.lisp
+++ b/lem-frontend-xcb/xcb-app/ft2.lisp
@@ -14,9 +14,10 @@
  (library ft2::ft-library)
   (filter :uint32))
 
+(defparameter *xcb-context* nil)
 (defun ft2init ()
-    (let ((result  (set-lcd-filter& ft2::*library* 1)))
-;      (format t "filter set; resultd ~A~&" result)
+  (let ((result  (set-lcd-filter& ft2::*library* 1)))
+    (setf *xcb-context* c)
       ))
 
 (defclass font ()
@@ -65,10 +66,11 @@
 	  (setf (gethash code mapbig) t)))
     code))
 
-(defmacro glyph-assure (font code)
-  `(if (> ,code 256)
-       (glyph-assure-long ,font ,code )
-       ,code))
+(defun glyph-assure (font code)
+;;  (format *q* "GLYPH-ASSURE.  Thread: ~A; c is |~A|~&" (bt:current-thread) *xcb-context*)
+  (if (> code 256)
+       (glyph-assure-long font code )
+       code))
 
 #||
 ;; load a glyphset
@@ -150,8 +152,9 @@
 	   (x-bitmap  (make-glyph-bitmap source w h s-pitch))
 	   (glyphinfo (make-glyphinfo w h (- left)  top (/ advance-x 64) 0)))
       (declare (ignore unused))
+      ;;(format *q* "WWWWW ~A ~A ~A ~&" (code-char code) (/ advance-x 64) (ft2::get-loaded-advance face nil))
       (w-foreign-values (pcode :uint32 code)
-	(check (add-glyphs c glyphset  1 pcode  glyphinfo (* 4 w h) x-bitmap)))
+	(check (add-glyphs *xcb-context* glyphset  1 pcode  glyphinfo (* 4 w h) x-bitmap)))
       (foreign-free x-bitmap)
       (foreign-free glyphinfo)
       ;; mark glyph as loaded

--- a/lem-frontend-xcb/xcb-app/lemwin.lisp
+++ b/lem-frontend-xcb/xcb-app/lemwin.lisp
@@ -122,20 +122,25 @@
 
 ;;==============================================================================
 (defmethod lem::interface-invoke ((implementation xcb-frontend) function)
-  (xbug "interface-invoke ~&")
+  (xbug "interface-invoke ~A~&" (bt:current-thread))
   (let ((result nil))
     (unwind-protect
-         (progn
-	   ;; create x window here, and start the loop.
-	   (in) (in1)(make-instance 'textwin :w (* 80 7) :h (* 24 14));TODO
-	   
-	   (setf *editor-thread* (funcall function))
-	   (setf result (input-loop *editor-thread*))))
+	 (in) (in1)
+	 (setf *editor-thread*
+	       (funcall function
+			(lambda ()
+			  (let* ((width (truncate (init-fonts)))
+				 (w (make-instance 'textwin :w (* 80 width) :h (* 24 14))))
+			    (setf (cell-width w) width)))))
+
+     	      
+      (setf result (input-loop *editor-thread*)))
 
     (when (and (typep result 'lem::exit-editor)
                (lem::exit-editor-value result))
 ;;      (format *q* "~&exit value: ~A~%" (lem::exit-editor-value result))
       )))
+
 
 ;; running in input-thread: process x events.  These do not call lem:send-event;
 ;; key processing and resizing just does its thing.

--- a/lem-frontend-xcb/xcb-app/xcb-system.lisp
+++ b/lem-frontend-xcb/xcb-app/xcb-system.lisp
@@ -59,21 +59,25 @@
 ;;(defparameter *gs-bold-italic* nil)
 
 ;; session-global initialization...
-(defun in1 ()
-;;  (setf sp (create-pen #xFFFFFFFF));; deprecated, but keep for tests
- ;;
+(defun init-fonts ()
   (ft2init)
   (setf *gs-normal*
 	(make-instance
 	 'font :path
-	 (asdf:system-relative-pathname 'lem-xcb "fonts/DejaVuSansMono.ttf")
+	 (asdf:system-relative-pathname 'lem-xcb ;;"fonts/mplus-1m-medium.ttf"
+					"fonts/DejaVuSansMono.ttf"
+					)
 	 :size 10)
 	*gs-bold*
 	(make-instance
 	 'font :path
-	 (asdf:system-relative-pathname 'lem-xcb "fonts/DejaVuSansMono-Bold.ttf")
+	 (asdf:system-relative-pathname 'lem-xcb ;;"fonts/mplus-1m-bold.ttf"
+					"fonts/DejaVuSansMono-Bold.ttf"
+					)
 	 :size 10))
-  
+  (ft2::get-loaded-advance (face *gs-normal*) nil) )
+
+(defun in1 ()
   ;; prepare the event subsystem
   (event-dispatch-reset)
   (event-push-handler EVENT-EXPOSE #'on-expose)


### PR DESCRIPTION
Moved Freetype2 initialization into `(interface-invoke)` editor-thread callback.  Freetype2 is not thread-safe and must be used in a single thread.  Since some glyphs (Kanji etc.) are loaded during printing, the editor thread must be used to initialize Freetype2, while the input loop runs in a different thread...  

It still does not handle double-width characters well, but at least it does not lock up as before.