### PR TITLE
refactor(rewrite?) show-paren

### DIFF
--- a/lem-core/showparen.lisp
+++ b/lem-core/showparen.lisp
@@ -5,8 +5,7 @@
            :backward-matching-paren))
 (in-package :lem.show-paren)
 
-(defvar *brackets-overlays* nil)
-
+(defvar *brackets-overlays* '())
 
 (define-attribute showparen-attribute
   (t :background "cyan"))
@@ -24,24 +23,42 @@
   (when (syntax-closed-paren-char-p (character-at p -1))
     (scan-lists (copy-point p :temporary) -1 0 t)))
 
-(defun show-paren-timer-function ()
+(defun show-paren-function ()
   (mapc #'delete-overlay *brackets-overlays*)
   (setq *brackets-overlays* nil)
   (let ((highlight-points '()))
-    (alexandria:when-let ((p (funcall (variable-value 'forward-matching-paren)  (current-point))))
-      (push (copy-point p :temporary) highlight-points))
-    (alexandria:when-let ((p (funcall (variable-value 'backward-matching-paren) (current-point))))
-      (push (copy-point p :temporary) highlight-points))
+    (or (alexandria:when-let ((p (funcall (variable-value 'backward-matching-paren) (current-point))))
+          (push (copy-point p :temporary) highlight-points)
+          (alexandria:when-let ((p (funcall (variable-value 'forward-matching-paren) p)))
+            (push (copy-point p :temporary) highlight-points)))
+        (alexandria:when-let ((p (funcall (variable-value 'forward-matching-paren)  (current-point))))
+          (push (copy-point p :temporary) highlight-points)))
     (dolist (point highlight-points)
       (push (make-overlay point
                           (character-offset (copy-point point :temporary) 1)
                           'showparen-attribute)
             *brackets-overlays*))))
 
-(defvar *show-paren-timer*)
+(defvar *show-paren-timer* nil)
 
-(when (or (not (boundp '*show-paren-timer*))
-          (not (timer-alive-p *show-paren-timer*)))
-  (setf *show-paren-timer*
-        (start-idle-timer 100 t
-                          'show-paren-timer-function nil "show paren timer")))
+(define-command toggle-show-paren () ()
+  (let ((p (not *show-paren-timer*)))
+    (when (interactive-p)
+      (message "show paren ~:[dis~;en~]abled." p))
+    (if p
+        (progn
+          (when *show-paren-timer*
+            (stop-timer *show-paren-timer*))
+          (setf *show-paren-timer*
+                (start-idle-timer 100 t
+                                  'show-paren-function nil "show paren timer"))
+          t)
+        (progn
+          (when *show-paren-timer*
+            (stop-timer *show-paren-timer*))
+          (mapc #'delete-overlay *brackets-overlays*)
+          (setq *brackets-overlays* nil)
+          (setf *show-paren-timer* nil)))))
+
+(unless *show-paren-timer*
+  (toggle-show-paren))


### PR DESCRIPTION
```
(define-command toggle-show-paren (&optional (p (not *show-paren-timer*))) () 
```

こう書きたいけど駄目なものでしょうか?意図が無いならassert外しちゃいますが。
I would like to use above expression. if there's no intention, I would like to remove assertion which prevent it.