### PR TITLE
Add `ncurses-ccl` frontend for platforms on which SBCL has no thread support

### DIFF
--- a/roswell/lem-ncurses-ccl.ros
+++ b/roswell/lem-ncurses-ccl.ros
@@ -1,0 +1,16 @@
+#!/bin/sh
+#|-*- mode:lisp -*-|#
+#| lem simple emacs clone 
+exec ros -Q -L ccl-bin -- $0 "$@"
+|#
+(progn
+  (ql:quickload :lem-ncurses :silent t)
+  (uiop:symbol-call :lem :load-site-init))
+
+(defpackage :ros.script.lem-ncurses-ccl.3724915314
+  (:use :cl))
+(in-package :ros.script.lem-ncurses-ccl.3724915314)
+
+(defun main (&rest argv)
+  (apply #'lem:lem argv))
+;;; vim: set ft=lisp lisp:


### PR DESCRIPTION
This PR simply add a ros script which uses ccl-bin instead of sbcl-bin. 
It is useful when use lem on the platforms on which SBCL has no thread supports such as raspberry pi. 
Originally, it is what personally I use on my chromebook. (see also #59)
Sorry for bad English.

このPRは単にsbcl-binの代わりにccl-binを使用するrosスクリプトを追加しただけです．
ラズパイのようなSBCLのスレッドサポートがないプラットフォームで有用と思います．
元々は，私が個人的にchromebookで使っているものです．(#59 の話です)