### PR TITLE
Build an executable for the ncurses interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,20 @@ all:
 
 %$(EXEEXT): %.ros
 	ros build $<
+
+build:
+	sbcl --load lem-core/lem-core.asd \
+	     --load lem-vi-mode/lem-vi-mode.asd \
+	     --load lem-lisp-mode/lem-lisp-mode.asd \
+	     --load lem-go-mode/lem-go-mode.asd \
+	     --load lem-c-mode/lem-c-mode.asd \
+	     --load lem.asd \
+	     --eval '(ql:quickload "lem")' \
+	     --eval '(ql:quickload "lem-ncurses")' \
+	     --eval '(asdf:make :lem)' \
+	     --eval '(quit)'
+
+
 clean:
 	rm -f roswell/lem-ncurses$(EXEEXT)
 install:

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ You can skip over writing tidy settings or installing many plugins as you do on 
 - MacOS 10.13+ 
 
 ## Installation
+
+### With Roswell
 Please install roswell at first.
 
 [Roswell Installation Guide](https://github.com/roswell/roswell/wiki/Installation)
@@ -32,6 +34,11 @@ $ ros install cxxxr/lem
 2. add the PATH in the initialization file(such as ~/.bashrc)
 export PATH=$PATH:~/.roswell/bin
 ```
+
+### With an executable
+See our releases to download a self-contained executable.
+
+You can build it with `make build`.
 
 ## Usage
 

--- a/lem-c-mode/lem-c-mode.asd
+++ b/lem-c-mode/lem-c-mode.asd
@@ -1,4 +1,4 @@
-(defsystem "lem-c-mode"
+(asdf:defsystem "lem-c-mode"
   :depends-on ("lem-core")
   :serial t
   :components ((:file "grammer")

--- a/lem-core/lem-core.asd
+++ b/lem-core/lem-core.asd
@@ -1,4 +1,4 @@
-(defsystem "lem-core"
+(asdf:defsystem "lem-core"
   :depends-on ("uiop"
                "alexandria"
                "swank"

--- a/lem-frontend-ncurses/lem-ncurses.asd
+++ b/lem-frontend-ncurses/lem-ncurses.asd
@@ -1,4 +1,4 @@
-(defsystem "lem-ncurses"
+(asdf:defsystem "lem-ncurses"
   :depends-on ("cffi"
                "cl-charms"
                "lem")

--- a/lem-go-mode/lem-go-mode.asd
+++ b/lem-go-mode/lem-go-mode.asd
@@ -1,4 +1,4 @@
-(defsystem "lem-go-mode"
+(asdf:defsystem "lem-go-mode"
   :depends-on ("lem-core" "yason")
   :serial t
   :components ((:file "go-mode")))

--- a/lem-lisp-mode/lem-lisp-mode.asd
+++ b/lem-lisp-mode/lem-lisp-mode.asd
@@ -1,4 +1,4 @@
-(defsystem "lem-lisp-mode"
+(asdf:defsystem "lem-lisp-mode"
   :depends-on ("alexandria"
                "trivial-types"
                "usocket"

--- a/lem-vi-mode/lem-vi-mode.asd
+++ b/lem-vi-mode/lem-vi-mode.asd
@@ -1,4 +1,4 @@
-(defsystem "lem-vi-mode"
+(asdf:defsystem "lem-vi-mode"
   :depends-on ("esrap")
   :serial t
   :components ((:file "core")

--- a/lem.asd
+++ b/lem.asd
@@ -1,5 +1,11 @@
-(defsystem "lem"
+(asdf:defsystem "lem"
   :version "1.1"
+
+  ;; Build an executable.
+  :build-operation "program-op"
+  :build-pathname "lem"
+  :entry-point "lem:lem"
+
   :depends-on ("lem-core"
                "lem-vi-mode"
                "lem-lisp-mode"


### PR DESCRIPTION
Hi,

I suggest to distribute Lem executables in addition of the Roswell installation process. This is the way I found and I'd like your feedback. Indeed, downloading an executable is easier and lighter than installing roswell and its dependencies, I'm sure it will make more people try Lem, and it's maybe easier to develop with (I don't know how you develop with Roswell).

A CI system can easily build a new binary at every new tag push.

I have many edits like so

    +(asdf:defsystem "lem-c-mode" 

because I need this to `C-c C-k` in Slime and for the make target, but there may be another way if that bothers you.

I didn't try for Electron yet.

Regards