### PR TITLE
Change version to correct format

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lem",
-  "version": "1.2",
+  "version": "1.2.0",
   "description": "lem frontend",
   "main": "lem-frontend-electron/index.js",
   "scripts": {


### PR DESCRIPTION
This request solve #165 . When npm installs package, npm tests the version of package. The version must use Semantic Versioning. When you updates version number of package.json, you will needs to use that. Thank you.