### PR TITLE
fix M-x crash problem for frontend based on electron.

### DIFF
--- a/lem-frontend-electron/lem-editor/keyevent.js
+++ b/lem-frontend-electron/lem-editor/keyevent.js
@@ -8,6 +8,40 @@ const CONVERT_TABLE = {
     "ArrowUp": "Up",
     "ArrowDown": "Down"
 };
+// bypass layout and locale settings of system. use Standard 101 layout and en_US locale.
+// https://www.w3.org/TR/uievents-code/#code-value-tables
+const CODE_VALUE_TABLE = {
+  "Backquote": ["`", "~"],
+  "Backslash": ["\\", "|"],
+  "BracketLeft": ["[", "{"],
+  "BracketRight": ["]", "}"],
+  "Comma": [",", "<"],
+  "Digit0": ["0", ")"],
+  "Digit1": ["1", "!"],
+  "Digit2": ["2", "@"],
+  "Digit3": ["3", "#"],
+  "Digit4": ["4", "$"],
+  "Digit5": ["5", "%"],
+  "Digit6": ["6", "^"],
+  "Digit7": ["7", "&"],
+  "Digit8": ["8", "*"],
+  "Digit9": ["9", "("],
+  "Equal": ["=", "+"],
+  "KeyA": ["a", "A"], "KeyB": ["b", "B"], "KeyC": ["c", "C"],
+  "KeyD": ["d", "D"], "KeyE": ["e", "E"], "KeyF": ["f", "F"],
+  "KeyG": ["g", "G"], "KeyH": ["h", "H"], "KeyI": ["i", "I"],
+  "KeyJ": ["j", "J"], "KeyK": ["k", "K"], "KeyL": ["l", "L"],
+  "KeyM": ["m", "M"], "KeyN": ["n", "N"], "KeyO": ["o", "O"],
+  "KeyP": ["p", "P"], "KeyQ": ["q", "Q"], "KeyR": ["r", "R"],
+  "KeyS": ["s", "S"], "KeyT": ["t", "T"], "KeyU": ["u", "U"],
+  "KeyV": ["v", "V"], "KeyW": ["w", "W"], "KeyX": ["x", "X"],
+  "KeyY": ["y", "Y"], "KeyZ": ["z", "Z"],
+  "Minus": ["-", "_"],
+  "Period": [".", ">"],
+  "Quote": ["'", "\""],
+  "Semicolon": [";", ":"],
+  "Slash": ["/", "?"]
+}
 
 exports.convertKeyEvent = function (e) {
     let key = e.key;
@@ -15,6 +49,7 @@ exports.convertKeyEvent = function (e) {
         return null;
     }
     key = CONVERT_TABLE[key] || key;
+    key = !e.shiftKey ? CODE_VALUE_TABLE[e.code][0] : CODE_VALUE_TABLE[e.code][1];
     return {
         "key": key,
         "ctrl": e.ctrlKey,

--- a/lem-frontend-electron/lem-editor/keyevent.js
+++ b/lem-frontend-electron/lem-editor/keyevent.js
@@ -1,4 +1,5 @@
 'use strict';
+const os = require('os');
 
 const MODIFIERS = ["Shift", "Control", "Alt", "Meta"];
 const CONVERT_TABLE = {
@@ -49,7 +50,9 @@ exports.convertKeyEvent = function (e) {
         return null;
     }
     key = CONVERT_TABLE[key] || key;
-    key = !e.shiftKey ? CODE_VALUE_TABLE[e.code][0] : CODE_VALUE_TABLE[e.code][1];
+    if (os.platform() == "darwin") {
+      key = !e.shiftKey ? CODE_VALUE_TABLE[e.code][0] : CODE_VALUE_TABLE[e.code][1];
+    }
     return {
         "key": key,
         "ctrl": e.ctrlKey,


### PR DESCRIPTION
Tested on macOS™.
On the os, key sequence Alt-option + X generates M-≈ but not M-x by default. that causes lem-rpc crashed.
There're few resorts we can take to resolve this issue on the application layer, or accurately a browser context. Nevertheless remapping the code to the value is a way.
