### PR TITLE
add a dependency: keyboard-layout to handle different keyboard layout

### DIFF
--- a/lem-frontend-electron/lem-editor/keyevent.js
+++ b/lem-frontend-electron/lem-editor/keyevent.js
@@ -1,5 +1,6 @@
 'use strict';
 const os = require('os');
+const KeyboardLayout = require('keyboard-layout');
 
 const MODIFIERS = ["Shift", "Control", "Alt", "Meta"];
 const CONVERT_TABLE = {
@@ -51,8 +52,9 @@ exports.convertKeyEvent = function (e) {
     }
     key = CONVERT_TABLE[key] || key;
     if (os.platform() == "darwin") {
+      var keyinfo = KeyboardLayout.getCurrentKeymap()[e.code];
       if (CODE_VALUE_TABLE.hasOwnProperty(e.code)) {
-        key = !e.shiftKey ? CODE_VALUE_TABLE[e.code][0] : CODE_VALUE_TABLE[e.code][1];
+        key = !e.shiftKey ? keyinfo["unmodified"] : keyinfo["withShift"];
       }
     }
     return {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "child_process": "^1.0.2",
     "electron": "^1.7.9",
+    "keyboard-layout": "^2.0.13",
     "marked": "^0.3.6",
     "utf-8": "^1.0.0",
     "vscode-jsonrpc": "^3.4.1"


### PR DESCRIPTION
add keyboard-layout package from atom.
the convert power comes from UCKeyTranslate on macOS.

if it works, the only disadvantage is that keyboard-layout brings native binary code dependency to this project, not that pure.
 
may the users not care.

incidentally, do `npm install` at project root directory to update the project dependency chain first before test.
