### PR TITLE
typeout-mode considered not apropriate for edit. so change it read-on…

### DIFF
--- a/lem-core/typeout.lisp
+++ b/lem-core/typeout.lisp
@@ -9,8 +9,10 @@
      :keymap *typeout-mode-keymap*))
 
 (define-key *typeout-mode-keymap* "q" 'quit-window)
+(define-key *typeout-mode-keymap* "Space" 'next-page)
+(define-key *typeout-mode-keymap* "Backspace" 'previous-page)
 
-(defun pop-up-typeout-window (buffer fn &key focus erase)
+(defun pop-up-typeout-window (buffer fn &key focus erase (read-only t))
   (let ((window (display-buffer buffer)))
     (with-current-window window
       (with-buffer-read-only buffer nil
@@ -20,7 +22,9 @@
         (when fn
           (save-excursion
             (with-open-stream (out (make-buffer-output-stream (buffer-end-point buffer)))
-              (funcall fn out))))))
+              (funcall fn out)))))
+      (when read-only
+        (setf (buffer-read-only-p buffer) t)))
     (when focus
       (setf (current-window) window))
     window))


### PR DESCRIPTION
qが入力できないしread onlyが基本で良いよね…

It seems ok to make it read only cause "q" is already impossible to input on the buffer.