### PR TITLE
close menu-mode when selected on lisp connections

### DIFF
--- a/lem-lisp-mode/lisp-mode.lisp
+++ b/lem-lisp-mode/lisp-mode.lisp
@@ -96,7 +96,8 @@
                                            (connection-implementation-version c)))
                   :select-callback (lambda (menu c)
                                      (change-current-connection c)
-                                     (lem.menu-mode:update-menu menu *connection-list*))
+                                     (lem.menu-mode:update-menu menu *connection-list*)
+                                     :close)
                   :update-items-function (lambda () *connection-list*))
    :name "Lisp Connections"))
 


### PR DESCRIPTION
on `lisp-connection-list` chose a connection would close the menu.