### PR TITLE
Add 'L' (move-to-window-bottom) key for vi-mode.

### DIFF
--- a/lem-vi-mode/binds.lisp
+++ b/lem-vi-mode/binds.lisp
@@ -30,6 +30,7 @@
 (define-key *command-keymap* "E" 'vi-forward-word-end-broad)
 (define-key *command-keymap* "$" 'vi-move-to-end-of-line)
 (define-key *command-keymap* "H" 'vi-move-to-window-top)
+(define-key *command-keymap* "L" 'vi-move-to-window-bottom)
 (define-key *command-keymap* "^" 'vi-back-to-indentation)
 (define-key *command-keymap* "{" 'backward-paragraph)
 (define-key *command-keymap* "}" 'forward-paragraph)

--- a/lem-vi-mode/commands.lisp
+++ b/lem-vi-mode/commands.lisp
@@ -20,6 +20,7 @@
            :vi-move-to-beginning-of-line
            :vi-move-to-end-of-line
            :vi-move-to-window-top
+           :vi-move-to-window-bottom
            :vi-back-to-indentation
            :vi-delete-next-char
            :vi-delete-previous-char
@@ -130,6 +131,10 @@
 
 (define-command vi-move-to-window-top () ()
   (move-point (current-point) (window-view-point (current-window))))
+
+(define-command vi-move-to-window-bottom () ()
+  (vi-move-to-window-top)
+  (next-line (- (window-height (current-window)) 2)))
 
 (define-command vi-back-to-indentation () ()
   (back-to-indentation-command))


### PR DESCRIPTION
Adding also `L`, for moving to the top of the window bottom line.

I don't get how to get the absolute line number to move, so it moves the window top once and calls `next-line` with `(- <window-height> 2)`.