### PR TITLE
[vi-mode] Find file from the current buffer directory with ':e'

### DIFF
--- a/lem-vi-mode/ex-command.lisp
+++ b/lem-vi-mode/ex-command.lisp
@@ -17,7 +17,7 @@
 (define-ex-command ("e") (range filename)
   (declare (ignore range))
   (lem:find-file (merge-pathnames filename
-                                  (uiop:getcwd))))
+                                  (lem:buffer-directory))))
 
 (define-ex-command ("w" "write") (range filename)
   (ex-write range filename))


### PR DESCRIPTION
`:e` in vi-mode finds files from the current directory, not current buffer's directory.