### PR TITLE
[vi-mode] File name completion for :e

### DIFF
--- a/lem-vi-mode/ex.lisp
+++ b/lem-vi-mode/ex.lisp
@@ -17,8 +17,28 @@
   )
 
 (define-command vi-ex () ()
-  (with-state 'ex
-    (execute-ex (prompt-for-line ":" "" nil nil 'vi-ex))))
+  (let ((directory (lem:buffer-directory)))
+    (with-state 'ex
+      (execute-ex
+       (prompt-for-line ":" ""
+                        (lambda (str)
+                          (when (alexandria:starts-with-subseq "e " str)
+                            ;; Almost same as minibuffer-file-complete in lem-core/completion-file.lisp
+                            ;; except item's :start offsets which will be used when selecting a completion item.
+                            (mapcar (lambda (filename)
+                                      (let ((label (lem.completion-mode::pathname-name* filename)))
+                                        (with-point ((s (lem::minibuffer-start-point))
+                                                     (e (lem::minibuffer-start-point)))
+                                          (lem.completion-mode::make-completion-item
+                                           :label label
+                                           :start (character-offset
+                                                   s
+                                                   (+ (length (namestring (uiop:pathname-directory-pathname (subseq str 2)))) 2))
+                                           :end (line-end e)))))
+                                    (lem.completion-mode::completion-file
+                                     (subseq str 2)
+                                     directory))))
+                        nil 'vi-ex)))))
 
 (defun execute-ex (string)
   (let ((lem-vi-mode.ex-core:*point* (current-point)))


### PR DESCRIPTION
It's almost the same as `minibuffer-file-complete` except the complete insertion offsets.