### PR TITLE
fix: at-keywords of css

### DIFF
--- a/lem-css-mode/css-mode.lisp
+++ b/lem-css-mode/css-mode.lisp
@@ -202,9 +202,9 @@
 
 (defvar *css22-at-keywords* 
   '(:sequence
-    :word-boundary
+    (:alternation :word-boundary :whitespace-char-class :start-anchor)
     (:regex "@[^\\s]+")
-    :word-boundary))
+    (:alternation :word-boundary :whitespace-char-class :end-anchor)))
 
 ; TODO ?
 ;; shape


### PR DESCRIPTION
fix syntax highlight rule for at-keywords of css.