### PR TITLE
fix: version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lem",
-  "version": "1.3",
+  "version": "1.3.0",
   "description": "lem frontend",
   "main": "lem-frontend-electron/index.js",
   "scripts": {


### PR DESCRIPTION
The version number (in package.json) must conform to the semantic version.

https://docs.npmjs.com/files/package.json#version
https://semver.org/