### PR TITLE
[vi-mode] Fix 'cc' not to remove the line.

### DIFF
--- a/lem-vi-mode/commands.lisp
+++ b/lem-vi-mode/commands.lisp
@@ -216,7 +216,8 @@
              (line-start start)
              (line-offset end (1- n))
              (line-end end)
-             (character-offset end 1)
+             (unless *vi-clear-recursive*
+               (character-offset end 1))
              (kill-region start end))
            (throw tag t))
           ((visual-p)
@@ -258,8 +259,10 @@
                       (end (current-point)))
            (kill-region start (line-end end))))))
 
+(defvar *vi-clear-recursive* nil)
 (define-command vi-clear () ()
-  (vi-delete)
+  (let ((*vi-clear-recursive* t))
+    (vi-delete))
   (vi-insert))
 
 (define-command vi-clear-line () ()


### PR DESCRIPTION
`dd` removes the line but `cc` doesn't.