### PR TITLE
[vi-mode] Fix 'cc' to work

### DIFF
--- a/lem-core/command.lisp
+++ b/lem-core/command.lisp
@@ -243,7 +243,7 @@
 
 (define-key *global-keymap* "C-p" 'previous-line)
 (define-key *global-keymap* "Up" 'previous-line)
-(define-command previous-line (&optional n) ("p")
+(define-command previous-line (&optional (n 1)) ("p")
   (next-line (- n)))
 
 (define-key *global-keymap* "C-f" 'forward-char)

--- a/lem-vi-mode/commands.lisp
+++ b/lem-vi-mode/commands.lisp
@@ -217,7 +217,6 @@
 (let ((tag (gensym)))
   (define-command vi-delete (&optional (n 1)) ("p")
     (cond (*vi-delete-recursive*
-           (move-to-beginning-of-line)
            (with-point ((start (current-point))
                         (end (current-point)))
              (line-start start)


### PR DESCRIPTION
Break at 2e8b1854edc7848629d8943f590c586ad8e086ec on #248 because of calling `previous-line` without arguments.