### PR TITLE
fix: package-dependency

### DIFF
--- a/lem-encodings/8bit.lisp
+++ b/lem-encodings/8bit.lisp
@@ -1,4 +1,4 @@
-(uiop/package:define-package :lem-encodings/8bit (:use :cl :lem-base))
+(uiop/package:define-package :lem-encodings/8bit (:use :cl :lem-base :lem-encodings/table))
 (in-package :lem-encodings/8bit)
 ;;;don't edit above
 

--- a/lem-encodings/lem-encodings.asd
+++ b/lem-encodings/lem-encodings.asd
@@ -2,5 +2,5 @@
 (defsystem "lem-encodings"
   :depends-on (:LEM-BASE)
   :class :package-inferred-system
-  :components ((:FILE "8bit") (:FILE "table") (:FILE "euc-jp") (:FILE "cp932")
+  :components ((:FILE "table") (:FILE "8bit") (:FILE "euc-jp") (:FILE "cp932")
  (:FILE "iso-8859-1") (:FILE "utf-8") (:FILE "utf-16")))


### PR DESCRIPTION
I try ```$ ros update lem```. However, following error message was displayed

```
[1/3] System 'lem' found. Loading the system..
; 
; caught ERROR:
;   READ error during COMPILE-FILE:
;   
;     Package LEM-ENCODINGS/TABLE does not exist.
;   
;       Line: 7, Column: 47, File-Position: 304
;   
;       Stream: #<SB-INT:FORM-TRACKING-STREAM for "file /home/satoaki/.roswell/local-projects/cxxxr/lem/lem-encodings/8bit.lisp" {10058C2EB3}>
Aborted during step [1/3].
Unhandled UIOP/LISP-BUILD:COMPILE-FILE-ERROR in thread #<SB-THREAD:THREAD "main thread" RUNNING
                                                          {1001928083}>:
  COMPILE-FILE-ERROR while compiling #<CL-SOURCE-FILE "lem-encodings" "8bit">
```

So, I try fix this phenomena. However, I'm worried this correction.

Could you check this correction is correct or no? 

Thank you. 