### PR TITLE
Removed form-feed character from source code

### DIFF
--- a/lem-base/buffer-insert.lisp
+++ b/lem-base/buffer-insert.lisp
@@ -228,7 +228,6 @@
                     (decf offset-line)
                 :finally (shift-markers point offset-line 0)))))))
 
-
 (declaim (inline call-before-change-functions
                  call-after-change-functions))
 

--- a/lem-base/syntax.lisp
+++ b/lem-base/syntax.lisp
@@ -183,7 +183,6 @@
                                       (syntax-table-block-string-pairs
                                        (current-syntax)))))
 
-
 (let ((cache (make-hash-table :test 'equal)))
   (defun %create-pair-regex (pair)
     (let ((tree
@@ -604,7 +603,6 @@
         (skip-chars-forward point #'syntax-symbol-char-p)
         (points-to-string start point)))))
 
-
 (defstruct pps-state
   type
   token-start-point

--- a/lem-base/tmlanguage.lisp
+++ b/lem-base/tmlanguage.lisp
@@ -130,7 +130,6 @@
 (defmethod %syntax-scan-region ((tmlanguage tmlanguage) start end)
   (tm-syntax-scan-region start end))
 
-
 (defun set-syntax-context (line x)
   (setf (line-%syntax-context line) x))
 

--- a/lem-core/completion-mode.lisp
+++ b/lem-core/completion-mode.lisp
@@ -167,7 +167,6 @@
 
 (setf *minibuffer-completion-function* 'minibuffer-completion)
 
-
 (defun pathname-name* (pathname)
   (enough-namestring
    pathname

--- a/lem-core/interface.lisp
+++ b/lem-core/interface.lisp
@@ -198,7 +198,6 @@
                        attribute))
     x))
 
-
 (defun redraw-line-p (y)
   (or (not *redraw-start-y*)
       (<= *redraw-start-y* y *redraw-end-y*)))

--- a/lem-core/isearch.lisp
+++ b/lem-core/isearch.lisp
@@ -75,7 +75,6 @@
 (define-key *global-keymap* "F3" 'isearch-next-highlight)
 (define-key *global-keymap* "Shift-F3" 'isearch-prev-highlight)
 
-
 (defun isearch-overlays (buffer)
   (buffer-value buffer 'isearch-overlays))
 
@@ -107,7 +106,6 @@
         (return (overlay-start prev)))
       (setf prev ov))))
 
-
 (defun isearch-update-buffer (&optional (point (current-point))
                                         (search-string *isearch-string*))
   (let ((buffer (point-buffer point)))
@@ -350,7 +348,6 @@
     ((boundp '*isearch-string*)
      (isearch-update-buffer))))
 
-
 (defvar *replace-before-string* nil)
 (defvar *replace-after-string* nil)
 

--- a/lem-core/streams.lisp
+++ b/lem-core/streams.lisp
@@ -154,7 +154,6 @@
 (defmethod trivial-gray-streams:clear-output ((stream buffer-output-stream))
   )
 
-
 (defclass minibuffer-input-stream (trivial-gray-streams:fundamental-input-stream)
   ((queue
     :initform nil
@@ -204,7 +203,6 @@
 (defmethod trivial-gray-streams:stream-clear-input ((stream minibuffer-input-stream))
   nil)
 
-
 (defclass editor-output-stream (trivial-gray-streams:fundamental-character-output-stream)
   ((pool
     :initform (make-string-output-stream))

--- a/lem-frontend-ncurses/term.lisp
+++ b/lem-frontend-ncurses/term.lisp
@@ -11,7 +11,6 @@
 
 (cffi:defcvar ("COLOR_PAIRS" *COLOR-PAIRS* :library charms/ll::libcurses) :int)
 
-
 (defvar *colors*)
 
 (defun color-red (color) (first color))
@@ -337,7 +336,6 @@
         (values color t)
         (values 0 nil))))
 
-
 (defvar *pair-counter* 0)
 (defvar *color-pair-table* (make-hash-table :test 'equal))
 
@@ -407,7 +405,6 @@
                                          (color-blue color)))))))
 
 ;;;
-
 (cffi:defcfun "fopen" :pointer (path :string) (mode :string))
 (cffi:defcfun "fclose" :int (fp :pointer))
 (cffi:defcfun "fileno" :int (fd :pointer))

--- a/lem-jsonrpc/jsonrpc.lisp
+++ b/lem-jsonrpc/jsonrpc.lisp
@@ -247,7 +247,6 @@
   (with-error-handler ()
     (notify "update-display" nil)))
 
-
 (defmacro define-enum (name &rest vars)
   (declare (ignore name))
   `(progn

--- a/lem-lisp-mode/lisp-mode.lisp
+++ b/lem-lisp-mode/lisp-mode.lisp
@@ -985,7 +985,6 @@
     ((:eof)
      (buffer-end point))))
 
-
 (defparameter *impl-name* nil)
 (defvar *slime-command-impls* '(roswell-impls-candidates
                                 qlot-impls-candidates))
@@ -1092,7 +1091,6 @@
     (self-connect))
   (when start-repl (start-lisp-repl)))
 
-
 (defun scan-current-package (point)
   (with-point ((p point))
     (loop

--- a/lem-vi-mode/core.lisp
+++ b/lem-vi-mode/core.lisp
@@ -30,7 +30,6 @@
   (:enable-hook #'enable-hook
    :disable-hook #'disable-hook))
 
-
 (defvar *modeline-element*)
 
 (define-attribute state-attribute
@@ -52,7 +51,6 @@
 (defun change-element-name (name)
   (setf (element-name *modeline-element*) name))
 
-
 (defstruct vi-state
   name
   keymap
@@ -107,7 +105,6 @@
        (unwind-protect (progn ,@body)
          (change-state ,old-state)))))
 
-
 (defvar *command-keymap* (make-keymap :name '*command-keymap*
                                       :parent *global-keymap*))
 (defvar *insert-keymap* (make-keymap :name '*insert-keymap* :parent *global-keymap*))


### PR DESCRIPTION
I found _form-feed_(`^L`) control character in source code;
I removed them because I thought it's not necessary.

Are there any custom in Lisp to treat _form-feed_ as special character?

> The form feed character is sometimes used in plain text files of source code as a delimiter for a page break, or as marker for sections of code. Some editors, in particular emacs and vi, have built-in commands to page up/down on the form feed character. This convention is predominantly used in Lisp code, and is also seen in C and Python source code.
(https://en.wikipedia.org/wiki/Page_break)

Anyway I thought we should remove _form-feed_ or maintain it and explain about it in documents, because it's not very popular rule.