### PR TITLE
Change the default string of 'prompt-for-file'

### DIFF
--- a/lem-core/defcommand.lisp
+++ b/lem-core/defcommand.lisp
@@ -47,13 +47,13 @@
                              ((char= #\f (aref arg-descripter 0))
                               `(prompt-for-file
                                 ,(subseq arg-descripter 1)
-                                (buffer-directory)
+                                (buffer-filename)
                                 nil
                                 t))
                              ((char= #\F (aref arg-descripter 0))
                               `(prompt-for-file
                                 ,(subseq arg-descripter 1)
-                                (buffer-directory)
+                                (buffer-filename)
                                 nil
                                 nil))
                              (t

--- a/lem-core/minibuffer.lisp
+++ b/lem-core/minibuffer.lisp
@@ -336,7 +336,7 @@
         default
         result)))
 
-(defun prompt-for-file (prompt &optional directory (default (buffer-directory)) existing)
+(defun prompt-for-file (prompt &optional directory (default (buffer-filename)) existing)
   (when default
     (setq prompt (format nil "~a(~a) " prompt default)))
   (let ((result


### PR DESCRIPTION
Since the default value is 'buffer-directory', it shows a directory name when C-c C-l (lisp-load-file).