### PR TITLE
Fix and enhancement of lem-pdcurses on windows

### DIFF
--- a/frontends/ncurses/term.lisp
+++ b/frontends/ncurses/term.lisp
@@ -8,7 +8,8 @@
            :term-finalize
            :term-set-tty
            ;;win32 patch
-           :*pos-adjust-mode*
+           :*windows-term-type*
+           :*windows-code-page*
            :get-mouse-mode
            :enable-mouse
            :disable-mouse))
@@ -16,16 +17,24 @@
 
 (cffi:defcvar ("COLOR_PAIRS" *COLOR-PAIRS* :library charms/ll::libcurses) :int)
 
-;; position adjustment mode
-;;   =0: no conversion
-;;   =1: wide character adjustment
-;;       (for ConEmu utf-8 mode (chcp 65001) (incomplete (unstable))
-;;   =2: wide character adjustment except cursor
-;;       (for mintty)
-(defvar *pos-adjust-mode*
-  (cond
-    ((uiop:getenv "ConEmuBuild") 1)
-    (t #+win32 2 #-win32 0)))
+;; windows terminal type
+;;   =0: none
+;;   =1: mintty  (winpty is needed)
+;;   =2: ConEmu  (experimental)
+;;        (Settings - Features - 'ANSI and xterm sequences' must be off)
+;;   =3: cmd.exe (experimental)
+(defvar *windows-term-type*
+  #-win32 0
+  #+win32 (cond
+            ((string= (uiop:getenv "MSYSCON") "mintty.exe") 1)
+            ((uiop:getenv "ConEmuBuild") 2)
+            (t 3)))
+
+;; windows console code page
+#+win32 (cffi:load-foreign-library '(:default "User32"))
+(defvar *windows-code-page*
+  #-win32 0
+  #+win32 (cffi:foreign-funcall "GetConsoleOutputCP" :int))
 
 ;; mouse mode
 ;;   =0: not use mouse


### PR DESCRIPTION
Windows 上の lem-pdcurses の表示について、少しデバッグや改善を行いました。

- C-| を C-_ (Redo) に変換する処理を追加
  (PDCurses が C-_ のイベントを上げられないため)

- 補完メニューの表示が日本語表示のところでずれる件の対策
  (まだ若干ずれるケースがありますが。。。)

- サロゲートペアの文字の表示の改善
  (ある程度表示できるようになりました。まだ若干ずれるケースがあります。。。)

- ConEmu 対応
  ConEmu の設定は、Settings - Features - ANSI and xterm sequences を OFF にする必要があります。
  また、pdcurses.dll にパスが通っている必要があります。
  起動方法は以下のようになります。
  ```
  ros -Q -s lem-pdcurses -L sbcl-bin -- %USERPROFILE%\.roswell\lisp\quicklisp\bin\lem-ncurses
  ```

- cmd.exe (コマンドプロンプト) 対応
  pdcurses.dll にパスが通っている必要があります。
  起動方法は以下のようになります。
  ```
  ros -Q -s lem-pdcurses -L sbcl-bin -- %USERPROFILE%\.roswell\lisp\quicklisp\bin\lem-ncurses
  ```

- その他、表示のデバッグ等
