### PR TITLE
Add eval function to scheme mode

### DIFF
--- a/modes/scheme-mode/grammer.lisp
+++ b/modes/scheme-mode/grammer.lisp
@@ -28,7 +28,7 @@
 (defun make-tmlanguage-scheme ()
   (let ((patterns (make-tm-patterns
                    (make-tm-region
-                    `(:alternation ";" "#!")
+                    `(:sequence ";")
                     "$"
                     :name 'syntax-comment-attribute)
                    ;; todo: nested comment
@@ -47,13 +47,29 @@
                     :name 'syntax-string-attribute
                     :patterns (make-tm-patterns
                                (make-tm-match "\\\\.")))
+                   ;; shebang (for Gauche)
+                   (make-tm-region
+                    `(:sequence :start-anchor "#!")
+                    "$"
+                    :name 'syntax-comment-attribute)
+                   ;; regexp (for Gauche)
                    (make-tm-region
                     `(:sequence "#/")
-                    `(:sequence "/i?")
+                    `(:sequence "/" (:greedy-repetition 0 1 #\i))
+                    :name 'syntax-constant-attribute
                     :patterns (make-tm-patterns
                                (make-tm-match "\\\\.")))
                    (make-tm-match
                     "\\\\.")
+                   (make-tm-match
+                    `(:sequence
+                      "("
+                      ,(wrap-symbol-names "define")
+                      "("
+                      (:greedy-repetition 0 1 (:register symbol)))
+                    :captures (vector nil
+                                      (make-tm-name 'syntax-keyword-attribute)
+                                      (make-tm-name 'syntax-function-name-attribute)))
                    (make-tm-match
                     `(:sequence
                       "("
@@ -93,11 +109,9 @@
                       "("
                       (:group
                        (:register (:sequence "make-" ,(ppcre:parse-string "\\S*"))))
-                      (:alternation (:greedy-repetition 1 nil :whitespace-char-class) :end-anchor)
-                      (:greedy-repetition 0 1 (:register symbol)))
+                      (:alternation (:greedy-repetition 1 nil :whitespace-char-class) :end-anchor))
                     :captures (vector nil
-                                      (make-tm-name 'syntax-keyword-attribute)
-                                      (make-tm-name 'syntax-variable-attribute)))
+                                      (make-tm-name 'syntax-keyword-attribute)))
                    (make-tm-match
                     `(:sequence
                       "("

--- a/modes/scheme-mode/lem-scheme-mode.asd
+++ b/modes/scheme-mode/lem-scheme-mode.asd
@@ -1,5 +1,6 @@
 (defsystem "lem-scheme-mode"
   :depends-on ("uiop"
+               "lem-process"
                "lem-core")
   :serial t
   :components ((:file "syntax-indent")

--- a/modes/scheme-mode/package.lisp
+++ b/modes/scheme-mode/package.lisp
@@ -5,8 +5,10 @@
   (:export
    ;; scheme-mode.lisp
    :*scheme-mode-keymap*
+   :*scheme-mode-hook*
    :scheme-beginning-of-defun
    :scheme-end-of-defun
-   :insert-\(\)
-   :move-over-\)
-   :scheme-indent-sexp))
+   :scheme-indent-sexp
+   :scheme-eval-last-expression
+   :scheme-eval-region
+   :*scheme-run-command*))

--- a/modes/scheme-mode/scheme-mode.lisp
+++ b/modes/scheme-mode/scheme-mode.lisp
@@ -3,7 +3,8 @@
 (define-major-mode scheme-mode language-mode
     (:name "scheme"
      :keymap *scheme-mode-keymap*
-     :syntax-table lem-scheme-syntax:*syntax-table*)
+     :syntax-table lem-scheme-syntax:*syntax-table*
+     :mode-hook *scheme-mode-hook*)
   (setf (variable-value 'beginning-of-defun-function) 'scheme-beginning-of-defun)
   (setf (variable-value 'end-of-defun-function) 'scheme-end-of-defun)
   (setf (variable-value 'indent-tabs-mode) nil)
@@ -14,6 +15,10 @@
   (set-syntax-parser lem-scheme-syntax:*syntax-table* (make-tmlanguage-scheme)))
 
 (define-key *scheme-mode-keymap* "C-M-q" 'scheme-indent-sexp)
+(define-key *scheme-mode-keymap* "C-c C-e" 'scheme-eval-last-expression)
+(define-key *scheme-mode-keymap* "C-c C-r" 'scheme-eval-region)
+
+(defparameter *scheme-run-command* "gosh -i")
 
 (defun calc-indent (point)
   (lem-scheme-syntax:calc-indent point))
@@ -47,6 +52,41 @@
   (with-point ((end (current-point) :right-inserting))
     (when (form-offset end 1)
       (indent-region (current-point) end))))
+
+(defvar *scheme-process* nil)
+
+(defun scheme-output-callback (string)
+  (let ((buffer (lem-process::process-buffer *scheme-process*)))
+    (with-current-window (pop-to-buffer buffer)
+      (buffer-end (buffer-point buffer)))
+    (redraw-display)))
+
+(defun scheme-run-process ()
+  (unless *scheme-process*
+    (setf *scheme-process* (lem-process:run-process
+                            *scheme-run-command* '()
+                            :name "*scheme-output*"
+                            :output-callback #'scheme-output-callback))
+    (lem-base::add-buffer (lem-process::process-buffer *scheme-process*))))
+
+(defun scheme-send-input (string)
+  (lem-process::process-send-input *scheme-process* string))
+
+(define-command scheme-eval-last-expression (p) ("P")
+  (with-point ((start (current-point))
+               (end   (current-point)))
+    (form-offset start -1)
+    (scheme-run-process)
+    (scheme-send-input (format nil "~A~%" (points-to-string start end)))))
+
+(define-command scheme-eval-region (start end) ("r")
+  (scheme-run-process)
+  (scheme-send-input (format nil "~A~%" (points-to-string start end))))
+
+(add-hook *exit-editor-hook*
+          (lambda ()
+            (when *scheme-process*
+              (lem-process:delete-process *scheme-process*))))
 
 (define-command scheme-scratch () ()
   (let ((buffer (make-buffer "*tmp*")))

--- a/modes/scheme-mode/scheme-mode.lisp
+++ b/modes/scheme-mode/scheme-mode.lisp
@@ -58,7 +58,8 @@
 (defun scheme-output-callback (string)
   (let ((buffer (lem-process::process-buffer *scheme-process*)))
     (with-current-window (pop-to-buffer buffer)
-      (buffer-end (buffer-point buffer)))
+      (buffer-end (buffer-point buffer))
+      (redraw-display))
     (redraw-display)))
 
 (defun scheme-run-process ()


### PR DESCRIPTION
Scheme モードに eval の機能を追加しました。
C-c C-e で直前の式を評価します。
C-c C-r でリージョンを評価します。
デフォルトでは gosh -i を起動します。

非同期通信には lem-process (async-process) を使用しています。
async-process のインストール方法は、
ros install cxxxr/async-process
で、エラーが出るので、インストール先フォルダで、
./bootstrap
を実行です。
(暫定かもしれませんが。。。)

あと、ハイライト処理をいくつか修正しました。
(defineの関数定義、make- 、正規表現(Gauche用)、shebangコメント(Gauche用))

`*global-keymap*` 対応ありがとうございます。

async-process もよい感じです。
