### PR TITLE
Set scheme process buffer to scheme mode

### DIFF
--- a/modes/scheme-mode/eval.lisp
+++ b/modes/scheme-mode/eval.lisp
@@ -6,7 +6,8 @@
   (defun scheme-process-buffer ()
     (unless buffer
       (setf buffer (make-buffer "*scheme-process*"))
-      (change-buffer-mode buffer 'scheme-mode))
+      (change-buffer-mode buffer 'scheme-mode)
+      (setf (variable-value 'enable-syntax-highlight :buffer buffer) nil))
     buffer))
 
 (defun scheme-output-callback (string)

--- a/modes/scheme-mode/grammer.lisp
+++ b/modes/scheme-mode/grammer.lisp
@@ -90,6 +90,7 @@
                     `(:sequence
                       "("
                       ,(wrap-symbol-names "define-class" "define-record-type")
+                      (:greedy-repetition 0 1 #\()
                       (:greedy-repetition 0 1 (:register symbol)))
                     :captures (vector nil
                                       (make-tm-name 'syntax-keyword-attribute)


### PR DESCRIPTION
scheme process buffer を scheme mode に設定するようにしました。
これにより、バッファ内で C-c C-e で評価が可能になりました。
(本物の repl のように enter で評価はできませんが。。。)

また、scheme のプロセスが終了していたら、再起動するようにしました。

あとハイライトを1箇所だけ修正しました。
