### PR TITLE
nim-mode follows nim v0.19.0 syntax

### DIFF
--- a/modes/nim-mode/nim-mode.lisp
+++ b/modes/nim-mode/nim-mode.lisp
@@ -48,18 +48,17 @@
 (defun make-tmlanguage-nim ()
   (let* ((patterns (make-tm-patterns
                     (make-tm-region "#" "$" :name 'syntax-comment-attribute)
-                    ;; keywords: https://nim-lang.org/docs/manual.html#lexical-analysis-identifiers-keywords
+                    ;; keywords: https://nim-lang.org/docs/manual.html#lexical-analysis-identifiers-amp-keywords
                     (make-tm-match (tokens :word-boundary
-                                           '("addr" "and" "as" "asm" "bind" "block" "break"
-                                             "case" "cast" "concept" "const" "continue" "converter"
-                                             "defer" "discard" "distinct" "div" "do" "elif" "else"
-                                             "end" "enum" "except" "export" "finally" "for" "from"
-                                             "func" "if" "import" "in" "include" "interface" "is"
-                                             "isnot" "iterator" "let" "macro" "method" "mixin" "mod"
-                                             "nil" "not" "notin" "object" "of" "or" "out" "proc"
-                                             "ptr" "raise" "ref" "return" "shl" "shr" "static"
-                                             "template" "try" "tuple" "type" "using" "var" "when"
-                                             "while" "xor" "yield"))
+                                           '("addr" "and" "as" "asm" "bind" "block" "break" "case"
+                                             "cast" "concept" "const" "continue" "converter" "defer"
+                                             "discard" "distinct" "div" "do" "elif" "else" "end" "enum"
+                                             "except" "export" "finally" "for" "from" "func" "if"
+                                             "import" "in" "include" "interface" "is" "isnot" "iterator"
+                                             "let" "macro" "method" "mixin" "mod" "nil" "not" "notin"
+                                             "object" "of" "or" "out" "proc" "ptr" "raise" "ref" "return"
+                                             "shl" "shr" "static" "template" "try" "tuple" "type" "using"
+                                             "var" "when" "while" "xor" "yield" ))
                                    :name 'syntax-keyword-attribute)
                     (make-tm-match (tokens :word-boundary
                                            '("false" "true" "nil"))

--- a/modes/nim-mode/nim-mode.lisp
+++ b/modes/nim-mode/nim-mode.lisp
@@ -58,7 +58,17 @@
                                              "let" "macro" "method" "mixin" "mod" "nil" "not" "notin"
                                              "object" "of" "or" "out" "proc" "ptr" "raise" "ref" "return"
                                              "shl" "shr" "static" "template" "try" "tuple" "type" "using"
-                                             "var" "when" "while" "xor" "yield" ))
+                                             "var" "when" "while" "xor" "yield"))
+                                   :name 'syntax-keyword-attribute)
+                    ;; basic types: https://nim-lang.org/docs/manual.html#types
+                    (make-tm-match (tokens :word-boundary
+                                           '("int" "int8" "int16" "int32" "int64" "uint" "uint8" "uint16"
+                                             "uint32" "uint64" "range" "float" "float32" "float64" "bool"
+                                             "enum" "char" "string" "cstring" "array" "seq" "openArray"
+                                             "varargs" "tuple" "object" "set" "addr" "ptr" "void" "auto"))
+                                   :name 'syntax-type-attribute)
+                    ;; operators: https://nim-lang.org/docs/manual.html#lexical-analysis-operators
+                    (make-tm-match (tokens nil'("=" "+" "-" "*" "/" "<" ">@" "$" "~" "&" "%" "|!" "?" "^" "." ":"))
                                    :name 'syntax-keyword-attribute)
                     (make-tm-match (tokens :word-boundary
                                            '("false" "true" "nil"))


### PR DESCRIPTION
## Changes

- some keywords added in Nim 0.19.0
- hilight types and operators

## Known issue

This PR hilight identifiers if the identifiers have same name as built-in types. For example, an image below, an identifier `seq` should not be hilighted:

![wrong-hilighting](https://user-images.githubusercontent.com/4403863/46753949-29358b80-ccfc-11e8-9461-534ff3cd3317.png)
