### PR TITLE
Fix display of Emoji characters on lem-pdcurses

### DIFF
--- a/frontends/pdcurses/ncurses-pdcurseswin32.lisp
+++ b/frontends/pdcurses/ncurses-pdcurseswin32.lisp
@@ -28,7 +28,7 @@
 (defmacro increment-disp-x (disp-x code)
   ;; check zero-width-space character (#\u200b)
   `(unless (= ,code #x200b)
-     (setf ,disp-x (lem-base:char-width (code-char ,code) ,disp-x))))
+     (incf ,disp-x (if (lem-base:wide-char-p (code-char ,code)) 2 1))))
 (defmacro increment-pos-x (pos-x code)
   `(incf ,pos-x (if (< ,code #x10000) 1 2)))
 (defmacro increment-cur-x (cur-x code)
@@ -38,7 +38,7 @@
 (defvar *wide-char-cursor-table* nil)
 (defun wide-char-cursor-p (code)
   ;; dummy (it should be remaked by lem-base::gen-binary-search-function)
-  (> (lem-base:char-width (code-char code) 0) 1))
+  (lem-base:wide-char-p (code-char code)))
 
 ;; for input
 ;; (we can't use stdscr for input because it calls wrefresh implicitly)
@@ -91,9 +91,9 @@
   (unless (and (eq *windows-term-type* :mintty)
                *wide-char-cursor-table*)
     (return-from mouse-get-pos-x x))
-  (let* ((cur-x 0)
-         (pos-x 0)
-         (pos-y (get-pos-y view x y)))
+  (let ((cur-x 0)
+        (pos-x 0)
+        (pos-y (get-pos-y view x y)))
     (loop :while (< cur-x x)
        :for code := (get-charcode-from-scrwin view pos-x pos-y)
        :do (increment-cur-x cur-x code)
@@ -640,7 +640,7 @@
           (charms/ll:wmove scrwin
                            (get-pos-y view lem::*cursor-x* lem::*cursor-y*)
                            ;; workaround for cursor position problem
-                           ;(get-pos-x view lem::*cursor-x* lem::*cursor-y*)
+                           ;;(get-pos-x view lem::*cursor-x* lem::*cursor-y*)
                            (get-cur-x view lem::*cursor-x* lem::*cursor-y*))))
     (charms/ll:wnoutrefresh scrwin)
     (charms/ll:doupdate)))


### PR DESCRIPTION
#348 で Unicode 11.0 の EastAsianWidth.txt のデータが反映されました。
それに関連して、lem-pdcurses で絵文字を表示してみて、
気になった点の修正を行いました。

いろいろ検討した結果、カーソル用の文字幅テーブルが必要になったため、
定義を追加しました。
ただ、実際のデータはソースに含めておらず init.lisp に記述することを想定しています。
(フォント設定等もからんでくるため)

追加した文字幅テーブル ( `*wide-char-cursor-table*` ) は、
Windows コンソールが (内部は不明ですが) 16 bit で文字の情報を扱っており、
サロゲートペアの文字 (コードポイントが #x10000 以上の文字) を
1行の半分の文字数までしか表示できないことから、必要となりました。

具体的には、変更前の Windows コンソール用の論理座標の計算は、
次のように行っていました。

|文字|lemが想定する<br>表示幅(disp-x)|Windowsコンソール<br>での論理幅(pos-x)|
|---|---|---|
|#\u41    (A)    |1  |1  |
|#\u3042  (あ)   |2  |1  |
|#\u1f363 (🍣 すし) |2  |2  |
|#\u1f000 (🀀 東牌) |1  |2  |

これを次のように変更しました。

|文字|lemが想定する<br>表示幅(disp-x)|Windowsコンソール<br>での論理幅(pos-x)|実際の表示幅<br>(=カーソルの移動幅)(cur-x)|
|---|---|---|---|
|#\u41    (A)    |1        |1  |1  |
|#\u3042  (あ)   |2        |1  |2  |
|#\u1f363 (🍣 すし) |2        |2  |2  |
|#\u1f000 (🀀 東牌) |2 ← 変更|2  |1  |

すなわち、サロゲートペアの文字 (コードポイントが #x10000 以上の文字) を、
lem としては一律 全角幅 として考え (これによって半分の文字数で行継続にしてもらう)、
カーソル位置のずれは別途 cur-x で調整するようにしました。

本内容を有効にする init.lisp の設定サンプルを、以下に載せておきます。
https://gist.github.com/Hamayama/12d5e637fc684e1d7e58e96aad5d0728
(without-package-locks や muffle-warning を使っているのが、
まずいかもしれませんが。。。)

init.lisp の設定を行わなかった場合には、おおむね今まで通りの動作となります。
すなわち、サロゲートペアの文字でかつ半角幅の文字 (#\u1f000 (東牌) 等) を表示すると、
後の文字が消えたり カーソル位置がずれたりします。
(逆に言うと、それ以外の問題は特にありませんが。。。)
