### PR TITLE
Fix mouse click position on lem-pdcurses

### DIFF
--- a/frontends/pdcurses/ncurses-pdcurseswin32.lisp
+++ b/frontends/pdcurses/ncurses-pdcurseswin32.lisp
@@ -64,24 +64,25 @@
           (lem:window-width  window)
           (lem:window-height window)))
 ;; for ConEmu
-;; get mouse pos-x for adjusting wide characters
-(defun mouse-get-pos-x (view x y)
+;; get mouse disp-x for pointing wide characters properly
+(defun mouse-get-disp-x (view x y)
   (unless (eq *windows-term-type* :conemu)
-    (return-from mouse-get-pos-x x))
-  (let ((disp-x 0)
-        (pos-x  0)
-        (pos-y  (get-pos-y view x y)))
-    (loop :while (< pos-x x)
-       :for c-code := (get-charcode-from-scrwin view pos-x pos-y)
-       :for c := (code-char c-code)
-       :do (setf disp-x (lem-base:char-width c disp-x))
-         (setf pos-x (+ pos-x (if (< c-code #x10000) 1 2))))
-    disp-x))
+    (return-from mouse-get-disp-x x))
+  (let* ((start-x (ncurses-view-x view))
+         (disp-x0 (+ x start-x))
+         (disp-x  start-x)
+         (pos-x   start-x)
+         (pos-y   (get-pos-y view x y)))
+    (loop :while (< pos-x disp-x0)
+       :for code := (get-charcode-from-scrwin view pos-x pos-y)
+       :do (setf disp-x (lem-base:char-width (code-char code) disp-x))
+         (setf pos-x (+ pos-x (if (< code #x10000) 1 2))))
+    (- disp-x start-x)))
 (defun mouse-move-to-cursor (window x y)
   (lem:move-point (lem:current-point) (lem::window-view-point window))
   (lem:move-to-next-virtual-line (lem:current-point) y)
   (lem:move-to-virtual-line-column (lem:current-point)
-                                   (mouse-get-pos-x (lem:window-view window) x y)))
+                                   (mouse-get-disp-x (lem:window-view window) x y)))
 (defun mouse-event-proc (bstate x1 y1)
   (lambda ()
     (cond
@@ -340,7 +341,8 @@
 ;; workaround for display update problem (incomplete)
 (defun force-refresh-display (width height)
   (loop :for y1 :from 0 :below height
-     ;; '#\.' is necessary ('#\space' doesn't work)
+     ;; clear display area to reset PDCurses's internal cache memory
+     ;; ('#\.' is necessary ('#\space' doesn't work))
      :with str := (make-string width :initial-element #\.)
      :do (charms/ll:mvwaddstr charms/ll:*stdscr* y1 0 str))
   (charms/ll:refresh)
@@ -417,18 +419,17 @@
          (pos-x    (if floating 0 start-x))
          (pos-y    (get-pos-y view x y :modeline modeline)))
     (loop :while (< disp-x disp-x0)
-       :for c-code := (get-charcode-from-scrwin view pos-x pos-y)
-       :for c := (code-char c-code)
-       :do (setf disp-x (lem-base:char-width c disp-x))
+       :for code := (get-charcode-from-scrwin view pos-x pos-y)
+       :do (setf disp-x (lem-base:char-width (code-char code) disp-x))
          ;; pos-x is incremented only 1 at wide characters
          ;; (except for utf-16 surrogate pair characters)
-         (setf pos-x (+ pos-x (if (< c-code #x10000) 1 2))))
+         (setf pos-x (+ pos-x (if (< code #x10000) 1 2))))
     pos-x))
 (defun get-pos-y (view x y &key (modeline nil))
   (+ y (ncurses-view-y view) (if modeline (ncurses-view-height view) 0)))
 
 ;; for mintty and ConEmu
-;; adjust line width by using zero-width-space characters (#\u200b)
+;; adjust line width by using zero-width-space character (#\u200b)
 (defun adjust-line (view x y &key (modeline nil))
   (unless (or (eq *windows-term-type* :mintty)
               (eq *windows-term-type* :conemu))
@@ -438,7 +439,7 @@
          (disp-x0    (+ disp-width start-x))
          (pos-x      (get-pos-x view disp-width y :modeline modeline))
          (pos-y      (get-pos-y view disp-width y :modeline modeline)))
-    ;; write zero-width-space characters (#\u200b)
+    ;; write string of zero-width-space character (#\u200b)
     ;; only when horizontal splitted window
     ;; (to reduce the possibility of copying zero-width-space characters to clipboard)
     (when (and (> disp-x0 pos-x)
@@ -452,11 +453,11 @@
   (let ((clist    '())
         (splitted nil))
     (loop :for c :across string
-       :for c-code := (char-code c)
-       :do (if (< c-code #x10000)
+       :for code := (char-code c)
+       :do (if (< code #x10000)
                (push c clist)
                ;; split to 2 characters
-               (multiple-value-bind (q r) (floor (- c-code #x10000) #x0400)
+               (multiple-value-bind (q r) (floor (- code #x10000) #x0400)
                  (push (code-char (+ q #xd800)) clist) ; leading surrogate
                  (push (code-char (+ r #xdc00)) clist) ; trailing surrogate
                  (setf splitted t))))
@@ -482,30 +483,31 @@
                (member *windows-code-page* '(932 936 949 950)))
     (charms/ll:mvwaddstr scrwin y x string)
     (return-from print-sub))
-  ;; clear display area
+  ;; clear display area to reset PDCurses's internal cache memory
+  ;; ('#\.' is necessary ('#\space' doesn't work))
   (let ((disp-width 0))
     (loop :for c :across string
-       :for c-code := (char-code c)
+       :for code := (char-code c)
        :do (incf disp-width)
          ;; check wide characters (except for cp932 halfwidth katakana)
-         (when (and (> c-code #x7f)
+         (when (and (> code #x7f)
                     (not (and (= *windows-code-page* 932)
-                              (<= #xff61 c-code #xff9f))))
+                              (<= #xff61 code #xff9f))))
            (incf disp-width)))
     (charms/ll:mvwaddstr scrwin y x
                          (make-string disp-width :initial-element #\.))
     (charms/ll:refresh))
   ;; display wide characters
   (loop :for c :across string
-     :for c-code := (char-code c)
+     :for code := (char-code c)
      :with pos-x := x
-     :do (charms/ll:mvwaddch scrwin y pos-x c-code)
+     :do (charms/ll:mvwaddch scrwin y pos-x code)
        (incf pos-x)
        ;; check wide characters (except for cp932 halfwidth katakana)
-       (when (and (> c-code #x7f)
+       (when (and (> code #x7f)
                   (not (and (= *windows-code-page* 932)
-                            (<= #xff61 c-code #xff9f))))
-         (charms/ll:mvwaddch scrwin y pos-x c-code)
+                            (<= #xff61 code #xff9f))))
+         (charms/ll:mvwaddch scrwin y pos-x code)
          (incf pos-x)
          (charms/ll:refresh))))
 


### PR DESCRIPTION
lem-pdcurses ですが、いろいろ触っていて、1件見つけたため修正しました。

マウスクリックの座標を取るところ ( mouse-get-pos-x ) で、
C-x 3 で画面を横分割して、右側の画面をクリックした場合に、
左側の画面情報を使って、座標を計算してしまっていました。

この処理は、ConEmu のときのみ使用されるため、
ConEmu 上で画面を横分割した場合のみ、不具合になります。

(テスト時は、左右同じ表示にしていたようで、気が付きませんでした。。。)

また、変数名の統一やコメント等、ロジックに影響のない範囲で、少し見直しをしました。
