### PR TITLE
Enhance response of lem-pdcurses

### DIFF
--- a/frontends/pdcurses/ncurses-pdcurseswin32.lisp
+++ b/frontends/pdcurses/ncurses-pdcurseswin32.lisp
@@ -1,4 +1,6 @@
 (in-package :lem-ncurses)
+(export '(get-input-polling-interval
+          set-input-polling-interval))
 
 ;; windows terminal type
 ;;   :mintty  : mintty  (winpty is needed)
@@ -13,10 +15,38 @@
 
 ;; load windows dll
 (cffi:load-foreign-library '(:default "kernel32"))
+(cffi:load-foreign-library '(:default "winmm"))
 
 ;; windows console code page
 (defvar *windows-code-page*
   (cffi:foreign-funcall "GetConsoleOutputCP" :int))
+
+;; input polling interval (sec)
+;;   (we don't use PDCurses's internal polling timer (0.05 sec interval))
+;;   (when interval is less than 0.01, high precision timer is used)
+(defvar *input-polling-interval* 0.01)
+(defun get-input-polling-interval ()
+  *input-polling-interval*)
+(let ((high-precision nil)
+      (exit-hook      nil))
+  (defun set-input-polling-interval (v)
+    (setf *input-polling-interval* v)
+    (cond
+      ((< v 0.01)
+       (unless high-precision
+         (setf high-precision t)
+         (cffi:foreign-funcall "timeBeginPeriod" :int 1 :int))
+       (unless exit-hook
+         (setf exit-hook t)
+         (add-hook *exit-editor-hook*
+                   (lambda ()
+                     (when high-precision
+                       (cffi:foreign-funcall "timeEndPeriod" :int 1 :int))))))
+      (t
+       (when high-precision
+         (setf high-precision nil)
+         (cffi:foreign-funcall "timeEndPeriod" :int 1 :int)))))
+  (set-input-polling-interval *input-polling-interval*))
 
 ;; for input
 ;; (we can't use stdscr for input because it calls wrefresh implicitly)
@@ -27,7 +57,7 @@
     (charms/ll:keypad *padwin* 1)
     (charms/ll:PDC-save-key-modifiers 1)
     ;; timeout setting is necessary to exit lem normally
-    (charms/ll:wtimeout *padwin* 100))
+    (charms/ll:wtimeout *padwin* 0))
   (charms/ll:wgetch *padwin*))
 
 ;; for resizing display
@@ -156,10 +186,12 @@
 ;; deal with utf-16 surrogate pair characters (input)
 (defun get-key (code)
   (when (<= #xd800 code #xdbff)
+    (charms/ll:wtimeout *padwin* 100)
     (let ((c-lead  code)
           (c-trail (getch-pad)))
       (when (<= #xdc00 c-trail #xdfff)
-        (setf code (+ #x10000 (* (- c-lead #xd800) #x0400) (- c-trail #xdc00))))))
+        (setf code (+ #x10000 (* (- c-lead #xd800) #x0400) (- c-trail #xdc00))))
+      (charms/ll:wtimeout *padwin* 0)))
   (char-to-key (code-char code)))
 
 ;; enable modifier keys
@@ -229,6 +261,7 @@
            ((= code #x210) (setf code #x05c))
            ;; M-[
            ((= code #x1f1)
+            (charms/ll:wtimeout *padwin* 100)
             (let ((code1 (getch-pad)))
               (cond
 		;; drop mouse escape sequence
@@ -237,7 +270,8 @@
                     :until (or (= code2 -1)
                                (= code2 #x04d)	   ; M
                                (= code2 #x06d)))   ; m
-                 (setf code -1)))))
+                 (setf code -1)))
+              (charms/ll:wtimeout *padwin* 0)))
            ))
         ;; normal key workaround
         (t
@@ -296,7 +330,8 @@
                (let ((event (get-event)))
                  (case event
                    ;; retry is necessary to exit lem normally
-                   (:retry)
+                   (:retry
+                    (sleep *input-polling-interval*))
                    (:abort
                     (send-abort-event editor-thread nil))
                    (t


### PR DESCRIPTION
PDCurses の getch ですが、内部では 50 msec 固定のポーリングとなっていました。
https://github.com/wmcbrine/PDCurses/blob/85ba3c7f7f782a0fa59e0239dd2cc1d7e596cc75/pdcurses/getch.c#L231
(timeout 設定が -1 のときも同じ)

50 msec というと、ゲーム等では、少し遅さを感じる時間なので、
調整ができるようにしてみました。
(timeout を 0 msec に設定して、sleep を自前で行う)

設定値が 0.01 (10 msec) 未満の場合には、
timeBeginPeriod (Windows API) を使って、
タイマを高精度 (15 msec → 1 msec 程度) にします。

すなわち、init.lisp に、
```
#+(and win32 lem-ncurses)
(lem-ncurses:set-input-polling-interval 0.001)
```
のように書くと、反応が目に見えて速くなります。

ただし、タイマを高精度にすると、その分 バッテリーの減りが速くなったりもするようです。
(これは、PC全体の設定になるようです)
そのため、デフォルトの設定にはしないようにしました。
