### PR TITLE
Fix disp-set-overlay for one line

### DIFF
--- a/lib/core/interface.lisp
+++ b/lib/core/interface.lisp
@@ -314,7 +314,13 @@
                                     attribute)))))
 
 (defun disp-set-overlay (screen attribute screen-row start end)
-  (disp-set-line screen attribute screen-row (point-charpos start) nil)
+  (let ((start-and-end-on-same-line (same-line-p start end)))
+    (disp-set-line screen attribute screen-row (point-charpos start)
+	         (if start-and-end-on-same-line
+		   (point-charpos end)
+		   nil))
+    (when start-and-end-on-same-line
+      (return-from disp-set-overlay)))
   (with-point ((point start))
     (line-offset point 1)
     (loop :for i :from (1+ screen-row)


### PR DESCRIPTION
If you mark, then scroll down, then scroll up and have the cursor on the first line, it renders wrong. 
1. setting the mark
![1](https://user-images.githubusercontent.com/14166099/56402441-4909b700-622b-11e9-94e9-369ef188d418.png)
2. scrolling down
![2](https://user-images.githubusercontent.com/14166099/56402445-4ad37a80-622b-11e9-9dea-42d6edba7e47.png)
3. almost there
![4](https://user-images.githubusercontent.com/14166099/56402448-4d35d480-622b-11e9-90f8-cd57deda0343.png)
4. incorrectly colors the rest 
![3](https://user-images.githubusercontent.com/14166099/56402446-4c04a780-622b-11e9-8adc-3c75ebdab8bc.png)

