### PR TITLE
Enable terminal color setting

### DIFF
--- a/frontends/ncurses/term.lisp
+++ b/frontends/ncurses/term.lisp
@@ -7,6 +7,7 @@
            :term-init
            :term-finalize
            :term-set-tty
+           :term-set-color
            ;;win32 patch
            :get-mouse-mode
            :enable-mouse
@@ -39,15 +40,18 @@
 (defun color-blue (color) (third color))
 (defun color-number (color) (fourth color))
 
+(defun term-set-color (index r g b &optional (call-init-color t))
+  (when call-init-color
+    (charms/ll:init-color index
+                          (round (* r 1000/255))
+                          (round (* g 1000/255))
+                          (round (* b 1000/255))))
+  (setf (aref *colors* index) (list r g b index)))
+
 (defun init-colors (n)
   (let ((counter 0))
     (flet ((add-color (r g b)
-             (when (<= 8 counter)
-               (charms/ll:init-color counter
-                                     (round (* r 1000/255))
-                                     (round (* g 1000/255))
-                                     (round (* b 1000/255))))
-             (setf (aref *colors* counter) (list r g b counter))
+             (term-set-color counter r g b (<= 8 counter))
              (incf counter)))
       (setf *colors* (make-array n))
       (add-color #x00 #x00 #x00)


### PR DESCRIPTION
MSYS2 の mintty 上で、winpty をかませて lem を起動したときに、
RGB 色の R と B が逆になって表示されていたため、
init.lisp で設定を可能にしてみました。

本変更を適用後、
init.lisp に以下のように記述することで、R と B が他の環境と同じになります。
```
;; for windows pdcurses
#+(and win32 lem-ncurses)
(progn
  ;; color setting
  (lem.term:term-set-color  0 #x00 #x00 #x00)
  (lem.term:term-set-color  1 #x00 #x00 #x80)
  (lem.term:term-set-color  2 #x00 #x80 #x00)
  (lem.term:term-set-color  3 #x00 #x80 #x80)
  (lem.term:term-set-color  4 #x80 #x00 #x00)
  (lem.term:term-set-color  5 #x80 #x00 #x80)
  (lem.term:term-set-color  6 #x80 #x80 #x00)
  (lem.term:term-set-color  7 #xc0 #xc0 #xc0)
  (lem.term:term-set-color  8 #x80 #x80 #x80)
  (lem.term:term-set-color  9 #x00 #x00 #xff)
  (lem.term:term-set-color 10 #x00 #xff #x00)
  (lem.term:term-set-color 11 #x00 #xff #xff)
  (lem.term:term-set-color 12 #xff #x00 #x00)
  (lem.term:term-set-color 13 #xff #x00 #xff)
  (lem.term:term-set-color 14 #xff #xff #x00)
  (lem.term:term-set-color 15 #xff #xff #xff))
```

どうも mintty や ConEmu については、自前で先頭 16 色の設定を持っていて、
lem (PDCurses) からの変更を、受け付けないようです。
そして、lem は自分の設定を正として近似色の番号を検索するために、
実際の表示色が変わってしまうようです。
このため、まずは Windows コンソールの標準的な設定ができるようにしました。
(以下のページの Console Legacy RGB Values の設定になります
 https://devblogs.microsoft.com/commandline/updating-the-windows-console-colors/ )

また、winpty については、16 色にしか、対応していないとのことです。
( https://github.com/rprichard/winpty/issues/108 )

ただ、実際に設定してみると、16色の場合には、前の方が見やすかったような気もします。

mintty の左上アイコンをクリックして、Options - Looks - Theme の設定で、
1回 dracula を選択 (Applyをクリック) してから mintty を選択すると、
色がうすくなって、若干見やすくなるようです。
(何で dracula を経由してからでないと、色がうまく変わらないのかは、
よく分かりませんが。。。)
