### PR TITLE
Fix sbcl usocket error

### DIFF
--- a/modes/lisp-mode/util.lisp
+++ b/modes/lisp-mode/util.lisp
@@ -15,6 +15,10 @@
            (usocket:address-in-use-error () nil)
            (usocket:socket-error (e)
              (warn "USOCKET:SOCKET-ERROR: ~A" e)
+             nil)
+           #+sbcl
+           (sb-bsd-sockets:socket-error (e)
+             (warn "SB-BSD-SOCKETS:SOCKET-ERROR: ~A" e)
              nil))
       (when socket
         (usocket:socket-close socket)


### PR DESCRIPTION
M-x start-lisp-repl を実行したときに、
usocket:socket-error ではなく sb-bsd-sockets:socket-error が発生していて、
キャッチできずエラーになることがあったため、判定を追加してみました。

エラー時のログは以下です。
```
Socket error in "bind": 10013 (アクセス許可で禁じられた方法でソケットにアクセスしようとしました。)
Backtrace for: #<SB-THREAD:THREAD "editor" RUNNING {10045F0BB3}>
0: ((LAMBDA NIL :IN UIOP/IMAGE:PRINT-BACKTRACE))
1: ((FLET "THUNK" :IN UIOP/STREAM:CALL-WITH-SAFE-IO-SYNTAX))
2: (SB-IMPL::%WITH-STANDARD-IO-SYNTAX #<CLOSURE (FLET "THUNK" :IN UIOP/STREAM:CALL-WITH-SAFE-IO-SYNTAX) {2E9EBCB}>)
3: (UIOP/STREAM:CALL-WITH-SAFE-IO-SYNTAX #<CLOSURE (LAMBDA NIL :IN UIOP/IMAGE:PRINT-BACKTRACE) {100723EB0B}> :PACKAGE :CL)
4: (LEM:POP-UP-BACKTRACE #<SB-BSD-SOCKETS:SOCKET-ERROR {1007146E43}>)
5: ((FLET "H0" :IN LEM::COMMAND-LOOP) #<SB-BSD-SOCKETS:SOCKET-ERROR {1007146E43}>)
6: (SB-KERNEL::%SIGNAL #<SB-BSD-SOCKETS:SOCKET-ERROR {1007146E43}>)
7: (ERROR #<SB-BSD-SOCKETS:SOCKET-ERROR {1007146E43}>)
8: (USOCKET:SOCKET-LISTEN "127.0.0.1" 64348 :REUSEADDRESS NIL :REUSE-ADDRESS T :BACKLOG 5 :ELEMENT-TYPE CHARACTER)
9: (LEM-LISP-MODE.UTIL:PORT-AVAILABLE-P 64348)
10: (LEM-LISP-MODE.UTIL:RANDOM-PORT)
11: (LEM-LISP-MODE:SELF-CONNECT)
12: (LEM-LISP-MODE:START-LISP-REPL)
13: (LEM:CALL-COMMAND LEM-LISP-MODE:START-LISP-REPL NIL)
14: (LEM:CALL-COMMAND LEM:EXECUTE-COMMAND NIL)
15: (LEM::COMMAND-LOOP)
16: (LEM::TOPLEVEL-COMMAND-LOOP #<CLOSURE (LAMBDA NIL :IN LEM::RUN-EDITOR-THREAD) {1004EAF09B}>)
17: ((LAMBDA NIL :IN LEM::RUN-EDITOR-THREAD))
18: ((LAMBDA NIL :IN BORDEAUX-THREADS::BINDING-DEFAULT-SPECIALS))
19: ((FLET "WITHOUT-INTERRUPTS-BODY-4" :IN SB-THREAD::INITIAL-THREAD-FUNCTION-TRAMPOLINE))
20: ((FLET SB-THREAD::WITH-MUTEX-THUNK :IN SB-THREAD::INITIAL-THREAD-FUNCTION-TRAMPOLINE))
21: ((FLET "WITHOUT-INTERRUPTS-BODY-1" :IN SB-THREAD::CALL-WITH-MUTEX))
22: (SB-THREAD::CALL-WITH-MUTEX #<CLOSURE (FLET SB-THREAD::WITH-MUTEX-THUNK :IN SB-THREAD::INITIAL-THREAD-FUNCTION-TRAMPOLINE) {2E9FB4B}> #<SB-THREAD:MUTEX "thread result lock" owner: #<SB-THREAD:THREAD "editor
23: (SB-THREAD::INITIAL-THREAD-FUNCTION-TRAMPOLINE #<SB-THREAD:THREAD "editor" RUNNING {10045F0BB3}> NIL #<CLOSURE (LAMBDA NIL :IN BORDEAUX-THREADS::BINDING-DEFAULT-SPECIALS) {10045F0B3B}> (#<SB-THREAD:THREAD "
24: ("foreign function: #x436248")
25: ("foreign function: #x4033E1")
```
