### PR TITLE
Reduce cpu usage in lisp-mode on Windows

### DIFF
--- a/modes/lisp-mode/lisp-mode.lisp
+++ b/modes/lisp-mode/lisp-mode.lisp
@@ -799,6 +799,9 @@
     (setf *wait-message-thread*
           (bt:make-thread (lambda ()
                             (loop
+                              ;; workaround for windows (to reduce cpu usage)
+                              #+win32 (sleep 0.001)
+
                               (unless (connected-p)
                                 (setf *wait-message-thread* nil)
                                 (return))


### PR DESCRIPTION
Windows 上で、lisp-mode に入ったり、M-x start-lisp-repl を実行すると、
CPU を 25% 程度消費し続けていました。

ループしている場所が分かったので、(sleep 0.001) を入れたところ、0% になりました。

どうも、message-waiting-p (usocket:wait-for-input) が、タイムアウト指定を無視して、
(戻り値が NIL のときでも) すぐに戻ってきているようでした。
