### PR TITLE
Fix window resize on lem-pdcurses

### DIFF
--- a/frontends/pdcurses/ncurses-pdcurseswin32.lisp
+++ b/frontends/pdcurses/ncurses-pdcurseswin32.lisp
@@ -361,7 +361,13 @@
 (defun resize-display ()
   (when *resizing*
     (setf *resizing* nil)
-    (charms/ll:resizeterm 0 0)
+    ;; wait to get window size certainly
+    (sleep 0.1)
+    ;; check resize error
+    (when (= (charms/ll:resizeterm 0 0) charms/ll:ERR)
+      ;; this is needed to clear PDCurses's inner event flag
+      (charms/ll:resizeterm (max 3 charms/ll:*lines*)
+                            (max 5 charms/ll:*cols*)))
     (charms/ll:erase)
     ;; workaround for display update problem (incomplete)
     (force-refresh-display charms/ll:*cols* charms/ll:*lines*)))


### PR DESCRIPTION
mintty 上で winpty をかませて lem-pdcurses を実行した場合に、
画面のリサイズに失敗することがあったため、修正しました。

入力として resize イベントが上がってくるのですが、
実際に画面サイズが変わるまでにラグがあるようで、
charms/ll:resizeterm をすぐに実行すると、
PDCurses 内部が古いサイズのままになることがありました。

また、charms/ll:resizeterm がエラーで戻ってきた場合に、
一度 charms/ll:resizeterm が成功するまでは、
PDCurses が、次の resize イベントを上げないようになっていたため、
エラー時には、現状サイズで一度 charms/ll:resizeterm を実行するようにしました。
