### PR TITLE
Add windows terminal setting to lem-pdcurses

### DIFF
--- a/frontends/pdcurses/ncurses-pdcurseswin32.lisp
+++ b/frontends/pdcurses/ncurses-pdcurseswin32.lisp
@@ -11,6 +11,81 @@
     ((uiop:getenv "ConEmuBuild") :conemu)
     (t :cmd.exe)))
 
+;; windows terminal setting
+(defclass windows-term-setting ()
+  ((disp-char-width ;; character width setting for display
+                    ;;   t        : use default function
+                    ;;   nil      : no conversion
+                    ;;   function : use custom function
+                    ;;                (lambda (code) width)
+    :initform nil
+    :initarg :disp-char-width)
+   (pos-char-width  ;; character width setting for position
+                    ;;   t        : use default function
+                    ;;   nil      : no conversion
+                    ;;   function : use custom function
+                    ;;                (lambda (code) width)
+    :initform nil
+    :initarg :pos-char-width)
+   (cur-char-width  ;; character width setting for cursor movement
+                    ;;   t        : use default function
+                    ;;   nil      : no conversion
+                    ;;   function : use custom function
+                    ;;                (lambda (code) width)
+    :initform nil
+    :initarg :cur-char-width)
+   ))
+(defvar *windows-term-setting*
+  (case *windows-term-type*
+    (:mintty
+     (make-instance 'windows-term-setting
+                    :disp-char-width t
+                    :pos-char-width  t
+                    :cur-char-width  t))
+    (:conemu
+     (make-instance 'windows-term-setting
+                    :disp-char-width t
+                    :pos-char-width  t
+                    :cur-char-width  nil))
+    (t
+     (make-instance 'windows-term-setting
+                    :disp-char-width nil
+                    :pos-char-width  nil
+                    :cur-char-width  nil))))
+(defun disp-char-width-func ()
+  (let ((fn (slot-value *windows-term-setting* 'disp-char-width)))
+    (if (functionp fn)
+        (lambda (code)
+          ;; check zero-width-space character (#\u200b)
+          (if (= code #x200b)
+              0
+              (funcall fn code)))
+        (lambda (code)
+          ;; check zero-width-space character (#\u200b)
+          (if (= code #x200b)
+              0
+              (if (lem-base:wide-char-p (code-char code)) 2 1))))))
+(defun pos-char-width-func ()
+  (let ((fn (slot-value *windows-term-setting* 'pos-char-width)))
+    (if (functionp fn)
+        fn
+        (lambda (code)
+          ;; check utf-16 surrogate pair characters
+          (if (< code #x10000) 1 2)))))
+(defun cur-char-width-func ()
+  (let ((fn (slot-value *windows-term-setting* 'cur-char-width)))
+    (if (functionp fn)
+        (lambda (code)
+          ;; check zero-width-space character (#\u200b)
+          (if (= code #x200b)
+              0
+              (funcall fn code)))
+        (lambda (code)
+          ;; check zero-width-space character (#\u200b)
+          (if (= code #x200b)
+              0
+              (if (lem-base:wide-char-p (code-char code)) 2 1))))))
+
 ;; load windows dll
 ;;  (we load winmm.dll with a full path because it isn't listed in
 ;;   windows knowndlls)
@@ -99,26 +174,43 @@
    :width width
    :height height))
 
-;; for mouse
+;; mouse function
 (defun mouse-get-window-rect (window)
   (values (lem:window-x      window)
           (lem:window-y      window)
           (lem:window-width  window)
           (lem:window-height window)))
-;; for ConEmu
+;; for mintty
+;; get mouse pos-x for pointing wide characters properly
+(defun mouse-get-pos-x (view x y)
+  (unless (slot-value *windows-term-setting* 'cur-char-width)
+    (return-from mouse-get-pos-x x))
+  (let ((cur-char-width-fn (cur-char-width-func))
+        (pos-char-width-fn (pos-char-width-func))
+        (cur-x 0)
+        (pos-x 0)
+        (pos-y y))
+    (loop :while (< cur-x x)
+       :for code := (get-charcode-from-scrwin view pos-x pos-y)
+       :do (incf cur-x (funcall cur-char-width-fn code))
+           (incf pos-x (funcall pos-char-width-fn code)))
+    pos-x))
+;; for mintty and ConEmu
 ;; get mouse disp-x for pointing wide characters properly
 (defun mouse-get-disp-x (view x y)
-  (unless (eq *windows-term-type* :conemu)
+  (unless (slot-value *windows-term-setting* 'pos-char-width)
     (return-from mouse-get-disp-x x))
-  (let* ((start-x (ncurses-view-x view))
+  (let* ((disp-char-width-fn (disp-char-width-func))
+         (pos-char-width-fn  (pos-char-width-func))
+         (start-x (ncurses-view-x view))
          (disp-x0 (+ x start-x))
          (disp-x  start-x)
          (pos-x   start-x)
          (pos-y   (get-pos-y view x y)))
     (loop :while (< pos-x disp-x0)
        :for code := (get-charcode-from-scrwin view pos-x pos-y)
-       :do (incf disp-x (if (lem-base:wide-char-p (code-char code)) 2 1))
-           (incf pos-x  (if (< code #x10000) 1 2)))
+       :do (incf disp-x (funcall disp-char-width-fn code))
+           (incf pos-x  (funcall pos-char-width-fn  code)))
     (- disp-x start-x)))
 (defun mouse-move-to-cursor (window x y)
   (lem:move-point (lem:current-point) (lem::window-view-point window))
@@ -127,6 +219,9 @@
                                    (mouse-get-disp-x (lem:window-view window) x y)))
 (defun mouse-event-proc (bstate x1 y1)
   (lambda ()
+    ;; workaround for cursor position problem
+    (setf x1 (mouse-get-pos-x (lem:window-view (lem:current-window)) x1 y1))
+    ;; process mouse event
     (cond
       ;; button1 down
       ((logtest bstate (logior charms/ll:BUTTON1_PRESSED
@@ -217,7 +312,8 @@
           (modifier-keys (charms/ll:PDC-get-key-modifiers)))
       (setf ctrl-key (logtest modifier-keys charms/ll:PDC_KEY_MODIFIER_CONTROL))
       (setf alt-key  (logtest modifier-keys charms/ll:PDC_KEY_MODIFIER_ALT))
-      ;;(dbg-log-format "code=~X ctrl=~S alt=~S" code ctrl-key alt-key)
+      ;;(unless (= code -1)
+      ;;  (dbg-log-format "code=~X ctrl=~S alt=~S" code ctrl-key alt-key))
       (cond
         ;; ctrl key workaround
         (ctrl-key
@@ -361,7 +457,13 @@
 (defun resize-display ()
   (when *resizing*
     (setf *resizing* nil)
-    (charms/ll:resizeterm 0 0)
+    ;; wait to get window size certainly
+    (sleep 0.1)
+    ;; check resize error
+    (when (= (charms/ll:resizeterm 0 0) charms/ll:ERR)
+      ;; this is needed to clear PDCurses's inner event flag
+      (charms/ll:resizeterm (max 3 charms/ll:*lines*)
+                            (max 5 charms/ll:*cols*)))
     (charms/ll:erase)
     ;; workaround for display update problem (incomplete)
     (force-refresh-display charms/ll:*cols* charms/ll:*lines*)))
@@ -417,11 +519,12 @@
 
 ;; for mintty and ConEmu
 ;; get pos-x/y for printing wide characters
-(defun get-pos-x (view x y &key (modeline nil) (cursor nil))
-  (unless (or (and (eq *windows-term-type* :mintty) (not cursor))
-              (eq *windows-term-type* :conemu))
+(defun get-pos-x (view x y &key (modeline nil))
+  (unless (slot-value *windows-term-setting* 'pos-char-width)
     (return-from get-pos-x (+ x (ncurses-view-x view))))
-  (let* ((floating (not (ncurses-view-modeline-scrwin view)))
+  (let* ((disp-char-width-fn (disp-char-width-func))
+         (pos-char-width-fn  (pos-char-width-func))
+         (floating (not (ncurses-view-modeline-scrwin view)))
          (start-x  (ncurses-view-x view))
          (disp-x0  (+ x start-x))
          (disp-x   (if floating 0 start-x))
@@ -429,17 +532,37 @@
          (pos-y    (get-pos-y view x y :modeline modeline)))
     (loop :while (< disp-x disp-x0)
        :for code := (get-charcode-from-scrwin view pos-x pos-y)
-       :do (incf disp-x (if (lem-base:wide-char-p (code-char code)) 2 1))
-           (incf pos-x  (if (< code #x10000) 1 2)))
+       :do (incf disp-x (funcall disp-char-width-fn code))
+           (incf pos-x  (funcall pos-char-width-fn  code)))
     pos-x))
 (defun get-pos-y (view x y &key (modeline nil))
   (+ y (ncurses-view-y view) (if modeline (ncurses-view-height view) 0)))
 
+;; for mintty
+;; get cur-x for moving cursor position properly
+(defun get-cur-x (view x y &key (modeline nil))
+  (unless (slot-value *windows-term-setting* 'cur-char-width)
+    (return-from get-cur-x (get-pos-x view x y :modeline modeline)))
+  (let* ((disp-char-width-fn (disp-char-width-func))
+         (pos-char-width-fn  (pos-char-width-func))
+         (cur-char-width-fn  (cur-char-width-func))
+         (start-x (ncurses-view-x view))
+         (disp-x0 (+ x start-x))
+         (disp-x  0)
+         (pos-x   0)
+         (pos-y   (get-pos-y view x y :modeline modeline))
+         (cur-x   0))
+    (loop :while (< disp-x disp-x0)
+       :for code := (get-charcode-from-scrwin view pos-x pos-y)
+       :do (incf disp-x (funcall disp-char-width-fn code))
+           (incf pos-x  (funcall pos-char-width-fn  code))
+           (incf cur-x  (funcall cur-char-width-fn  code)))
+    cur-x))
+
 ;; for mintty and ConEmu
 ;; adjust line width by using zero-width-space character (#\u200b)
 (defun adjust-line (view x y &key (modeline nil))
-  (unless (or (eq *windows-term-type* :mintty)
-              (eq *windows-term-type* :conemu))
+  (unless (slot-value *windows-term-setting* 'pos-char-width)
     (return-from adjust-line))
   (let* ((start-x    (ncurses-view-x view))
          (disp-width (ncurses-view-width view))
@@ -587,6 +710,8 @@
           (charms/ll:curs-set 1)
           (charms/ll:wmove scrwin
                            (get-pos-y view lem::*cursor-x* lem::*cursor-y*)
-                           (get-pos-x view lem::*cursor-x* lem::*cursor-y* :cursor t))))
+                           ;; workaround for cursor position problem
+                           ;;(get-pos-x view lem::*cursor-x* lem::*cursor-y*)
+                           (get-cur-x view lem::*cursor-x* lem::*cursor-y*))))
     (charms/ll:wnoutrefresh scrwin)
     (charms/ll:doupdate)))

--- a/frontends/pdcurses/ncurses-pdcurseswin32.lisp
+++ b/frontends/pdcurses/ncurses-pdcurseswin32.lisp
@@ -55,11 +55,7 @@
 (defun disp-char-width-func ()
   (let ((fn (slot-value *windows-term-setting* 'disp-char-width)))
     (if (functionp fn)
-        (lambda (code)
-          ;; check zero-width-space character (#\u200b)
-          (if (= code #x200b)
-              0
-              (funcall fn code)))
+        fn
         (lambda (code)
           ;; check zero-width-space character (#\u200b)
           (if (= code #x200b)
@@ -75,11 +71,7 @@
 (defun cur-char-width-func ()
   (let ((fn (slot-value *windows-term-setting* 'cur-char-width)))
     (if (functionp fn)
-        (lambda (code)
-          ;; check zero-width-space character (#\u200b)
-          (if (= code #x200b)
-              0
-              (funcall fn code)))
+        fn
         (lambda (code)
           ;; check zero-width-space character (#\u200b)
           (if (= code #x200b)


### PR DESCRIPTION
- lem-pdcurses には、ワイド文字に関する処理がいろいろと入っていますが、
  もう少し整理しようと思い、
  windows-term-setting クラスを追加してみました。

- ワイド文字対応の処理は、主に以下の３種類の幅の変換になっています。
  (1) 表示の幅
  (2) 位置(座標)の幅 (例えば、Windows コンソールでは、Unicode のサロゲートペアの文字が 2 で、それ以外の文字が 1 になります)
  (3) カーソル移動の幅 (例えば、mintty では表示の幅で指定、ConEmu では位置の幅で指定、というように異なります)

- それぞれについて、変換あり / 変換なし / 関数によるカスタマイズ、を、
  `*windows-term-setting*` のプロパティで選択できるようにしました。
  デフォルトの設定は、以下のようにしています。
  
  |タイプ|表示の幅|位置の幅|カーソル移動の幅
  |---|---|---|---|
  |mintty |○|○|○|
  |ConEmu |○|○|×|
  |cmd.exe|×|×|×|
  
  ○:変換あり
  ×:変換なし

- これで、今後、対応する端末のタイプが増えても、
  個別の名称で全箇所に分岐を追加する必要がなくなると思います。
  (ただ、新しく Windows Terminal というのが出てきていて、
  今後は Windows Console API が非推奨になりそうとのことで、
  PDCurses 自体が不要になりそうですが。。。)

- 実際には、きれいにいかないケースもあって、現状、それらは個別に対応しています。
  例えば、以下があります。
  1. 画面を左右に分割すると、lem が右画面を先に表示するケースがあり、
     単純に左端から幅をカウントしていると、後から左画面を更新されて、
     右画面の文字が消えたり、化けたりする。
     このため、ゼロ幅文字 (#\u200b) を使って、
     左画面の文字数と表示幅が常に一定になるように調整している (adjust-line のところ)。
  2. cmd.exe は、表示が全くうまくいかず、
     仕方がないので、専用の処理を入れて対応している (print-sub のところ)。
     具体的には、表示エリアを一度消去してから、
     同じ文字コードを位置をずらして2回ずつ書いている。
     (PDCurses の内部キャッシュの問題かもしれない)

- 関数によるカスタマイズの例は、現在工事中ですが、以下のページに載せる予定です。
  https://gist.github.com/Hamayama/12d5e637fc684e1d7e58e96aad5d0728
  (内容としては、#354 の件に対応したものになる予定です。
  あいかわらず、こちらは分かりにくくなってしまうと思いますが。。。)
