### PR TITLE
Refactor lem-pdcurses (char-width processing, mouse function, etc.)

### DIFF
--- a/frontends/pdcurses/ncurses-pdcurseswin32.lisp
+++ b/frontends/pdcurses/ncurses-pdcurseswin32.lisp
@@ -35,8 +35,8 @@
     :initform nil
     :initarg :cur-char-width)
    (cur-mov-by-pos  ;; cursor movement setting
-                    ;;   t   : cursor movement is specified by pos
-                    ;;   nil : cursor movement is specified by cur
+                    ;;   t   : cursor movement is specified by pos-char-width
+                    ;;   nil : cursor movement is specified by cur-char-width
     :initform nil
     :initarg :cur-mov-by-pos)
    ))
@@ -203,9 +203,9 @@
           (slot-value *windows-term-setting* 'disp-char-width)
           (slot-value *windows-term-setting* 'pos-char-width))
      ;; for ConEmu
-     (let* ((disp-x 0)
-            (pos-x  0)
-            (pos-y  y))
+     (let ((disp-x 0)
+           (pos-x  0)
+           (pos-y  y))
        (loop :while (< pos-x x)
           :for code := (get-charcode-from-scrwin view pos-x pos-y)
           :until (= code charms/ll:ERR)
@@ -220,9 +220,9 @@
     ((and (slot-value *windows-term-setting* 'cur-mov-by-pos)
           (slot-value *windows-term-setting* 'pos-char-width)
           (slot-value *windows-term-setting* 'cur-char-width))
-     (let* ((pos-x 0)
-            (pos-y y)
-            (cur-x 0))
+     (let ((pos-x 0)
+           (pos-y y)
+           (cur-x 0))
        (loop :while (< pos-x x)
           :for code := (get-charcode-from-scrwin view pos-x pos-y)
           :until (= code charms/ll:ERR)


### PR DESCRIPTION
- #380 の続きで、処理の見直しを行いました。
  - disp-char-width, pos-char-width, cur-char-width を defmethod にしてみました。
  - マウスの処理の修正/見直し (分割線のマウスによる移動がうまくできないケースがありました)
  - エラーチェックの追加等

- 今回、ざっとですがテストをしたので、結果を以下に載せておきます。
  https://gist.github.com/Hamayama/452e4cc31ad9a5c479dad0b88613888f
  ( init.lisp 有りと無しの場合について、(1) mintty + winpty, (2) ConEmu, (3) cmd.exe 
  の３端末で動作確認しました )
  基本的には、大丈夫かと思います。
