### PR TITLE
Fix buffer menu selection mismatch

### DIFF
--- a/lib/core/list-buffers.lisp
+++ b/lib/core/list-buffers.lisp
@@ -7,6 +7,27 @@
 
 (define-key *global-keymap* "C-x C-b" 'list-buffers)
 
+(defun buffer-list-changed-p (menu &optional (msg-on nil))
+  (cond
+    ((set-exclusive-or (buffer-list)
+                       (lem.menu-mode::menu-origin-items menu)
+                       :test 'equal)
+     (let ((items (funcall (lem.menu-mode::menu-update-items-function menu))))
+       (update-menu menu items))
+     (when msg-on
+       (message "Buffer list has been changed. Please select again."))
+     t)
+    (t nil)))
+
+(defun menu-change-buffer (menu buffer)
+  (unless (buffer-list-changed-p menu t)
+    buffer))
+
+(defun menu-delete-buffer (menu buffer)
+  (unless (buffer-list-changed-p menu t)
+    (kill-buffer buffer)
+    :redraw))
+
 (define-command list-buffers () ()
   ;; copy-list is necessary to detect buffer list changes
   (let ((menu

--- a/lib/core/list-buffers.lisp
+++ b/lib/core/list-buffers.lisp
@@ -7,24 +7,23 @@
 
 (define-key *global-keymap* "C-x C-b" 'list-buffers)
 
-(defun buffer-list-changed-p (menu &optional (msg-on nil))
+(defun check-buffer-list-consistency (menu)
   (cond
     ((set-exclusive-or (buffer-list)
                        (lem.menu-mode::menu-origin-items menu)
                        :test 'equal)
      (let ((items (funcall (lem.menu-mode::menu-update-items-function menu))))
        (update-menu menu items))
-     (when msg-on
-       (message "Buffer list has been changed. Please select again."))
-     t)
-    (t nil)))
+     (message "Buffer list has been changed. Please select again.")
+     nil)
+    (t t)))
 
 (defun menu-change-buffer (menu buffer)
-  (unless (buffer-list-changed-p menu t)
+  (when (check-buffer-list-consistency menu)
     buffer))
 
 (defun menu-delete-buffer (menu buffer)
-  (unless (buffer-list-changed-p menu t)
+  (when (check-buffer-list-consistency menu)
     (kill-buffer buffer)
     :redraw))
 

--- a/lib/core/list-buffers.lisp
+++ b/lib/core/list-buffers.lisp
@@ -8,17 +8,21 @@
 (define-key *global-keymap* "C-x C-b" 'list-buffers)
 
 (define-command list-buffers () ()
-  (display-menu
-   (make-instance 'menu
-                  :columns '("Attributes" "Buffer" "File")
-                  :items (buffer-list)
-                  :column-function (lambda (buffer)
-                                     (list (format nil "~:[-~;%~]~:[-~;%~]"
-                                                   (buffer-modified-p buffer)
-                                                   (buffer-read-only-p buffer))
-                                           (buffer-name buffer)
-                                           (buffer-filename buffer)))
-                  :select-callback #'menu-change-buffer
-                  :delete-callback #'menu-delete-buffer
-                  :update-items-function (lambda () (buffer-list)))
-   :name "Buffer Menu"))
+  ;; copy-list is necessary to detect buffer list changes
+  (let ((menu
+         (make-instance 'menu
+                        :columns '("Attributes" "Buffer" "File")
+                        :items (copy-list (buffer-list))
+                        :column-function (lambda (buffer)
+                                           (list (format nil "~:[-~;%~]~:[-~;%~]"
+                                                         (buffer-modified-p buffer)
+                                                         (buffer-read-only-p buffer))
+                                                 (buffer-name buffer)
+                                                 (buffer-filename buffer)))
+                        :select-callback #'menu-change-buffer
+                        :delete-callback #'menu-delete-buffer
+                        :update-items-function (lambda () (copy-list (buffer-list))))))
+    (display-menu menu :name "Buffer Menu")
+    ;; update is necessary to add the buffer menu itself
+    (let ((items (funcall (lem.menu-mode::menu-update-items-function menu))))
+      (update-menu menu items))))

--- a/lib/core/menu-mode.lisp
+++ b/lib/core/menu-mode.lisp
@@ -2,9 +2,7 @@
   (:use :cl :lem)
   (:export :menu
            :display-menu
-           :update-menu
-           :menu-change-buffer
-           :menu-delete-buffer)
+           :update-menu)
   #+sbcl
   (:lock t))
 (in-package :lem.menu-mode)
@@ -142,31 +140,12 @@
   (setf (menu-origin-items menu) items)
   (display-menu menu :name (menu-name menu)))
 
-(defun menu-change-buffer (menu buffer)
-  (declare (ignore menu))
-   buffer)
-
-(defun menu-delete-buffer (menu buffer)
-  (declare (ignore menu))
-  (kill-buffer buffer)
-  :redraw)
-
 (defun menu-select-1 (&key (set-buffer #'switch-to-buffer)
                            ((:callback reader) #'menu-select-callback)
                            marked)
   (alexandria:when-let* ((menu (buffer-value (current-buffer) 'menu))
                          (callback (funcall reader menu))
                          (items (menu-current-items :marked marked)))
-
-    ;; check whether buffer list has been changed
-    (unless (null (set-exclusive-or (buffer-list)
-                                    (menu-origin-items menu)
-                                    :test 'equal))
-      (let ((items (funcall (menu-update-items-function menu))))
-        (update-menu menu items))
-      (message "Buffer list has been changed. Please select again.")
-      (return-from menu-select-1))
-
     (loop :with cb := (current-buffer)
           :with cw := (current-window)
           :with redraw

--- a/lib/core/menu-mode.lisp
+++ b/lib/core/menu-mode.lisp
@@ -157,6 +157,14 @@
   (alexandria:when-let* ((menu (buffer-value (current-buffer) 'menu))
                          (callback (funcall reader menu))
                          (items (menu-current-items :marked marked)))
+
+    ;; check whether buffer list has been changed
+    (unless (equal (buffer-list) (menu-origin-items menu))
+      (let ((items (funcall (menu-update-items-function menu))))
+        (update-menu menu items))
+      (message "Buffer list has been changed. Please select again.")
+      (return-from menu-select-1))
+
     (loop :with cb := (current-buffer)
           :with cw := (current-window)
           :with redraw

--- a/lib/core/menu-mode.lisp
+++ b/lib/core/menu-mode.lisp
@@ -159,7 +159,9 @@
                          (items (menu-current-items :marked marked)))
 
     ;; check whether buffer list has been changed
-    (unless (equal (buffer-list) (menu-origin-items menu))
+    (unless (null (set-exclusive-or (buffer-list)
+                                    (menu-origin-items menu)
+                                    :test 'equal))
       (let ((items (funcall (menu-update-items-function menu))))
         (update-menu menu items))
       (message "Buffer list has been changed. Please select again.")


### PR DESCRIPTION
C-x C-b (または M-x list-buffers) で buffer menu の画面を出したときに、
実際よりも少ない数のバッファが表示されたり、
表示と異なるバッファが選択されてしまったりする件を修正してみました。
(今までは、操作前に g キーを押すことで回避していました)

原因は、表示時点のバッファリストを menu-origin-items に記憶しているのですが、
これが、実際の `*buffer-list*` とポインタが共有されており、
`*buffer-list*` が更新されると、リストの途中を指すようになったりして、
誤動作していました。

対策としては、バッファリストの list-copy をとってから記憶するようにして、
選択時には、記憶内容と実際の `*buffer-list*` を比較し、
異なるときはメッセージを表示して、操作を実行しないようにしました。
