### PR TITLE
Add an additional config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ You can watch the screencast on Youtube.
 
 Lem loads `~/.lem/init.lisp` when starting up.
 
-You can see an example at [here](lemrc-example).
+You can see an example [here](lemrc-example) or [here](https://github.com/Fedreg/.lem/blob/master/init.lisp)
 
 fukamachi also published his init files on GitHub.
 https://github.com/fukamachi/.lem


### PR DESCRIPTION
Just added a link to my `.lem/init.lisp` sample config in the README.md.   I didn't want to modify the official `lemrc-example` but I can add a new file such as `lemrc-example2`, etc, if you prefer.