### PR TITLE
Improve slime connection on Windows

### DIFF
--- a/modes/lisp-mode/lisp-mode.lisp
+++ b/modes/lisp-mode/lisp-mode.lisp
@@ -1256,12 +1256,10 @@
 #+win32
 (progn
   (defun slime-quit-all-for-win32 ()
-    "quit slime and close sockets to exit lem normally on windows"
-    (let ((conn-list (copy-list *connection-list*)))
-      (slime-quit-all)
-      (dolist (c conn-list)
-        (usocket:socket-close
-         (lem-lisp-mode.swank-protocol::connection-socket c)))))
+    "quit slime and remove connection to exit lem normally on windows (incomplete)"
+    (slime-quit-all)
+    (loop :while *connection*
+          :do (remove-connection *connection*)))
   (add-hook *exit-editor-hook* 'slime-quit-all-for-win32))
 
 (pushnew (cons ".lisp$" 'lisp-mode) *auto-mode-alist* :test #'equal)

--- a/modes/lisp-mode/lisp-mode.lisp
+++ b/modes/lisp-mode/lisp-mode.lisp
@@ -121,11 +121,6 @@
   (let ((port (random-port)))
     (let ((swank::*swank-debug-p* nil))
       (swank:create-server :port port))
-
-    ;; workaround for windows
-    ;;  ('Thread not found: :REPL-THREAD' is returned from swank-server)
-    #+win32(sleep 1.0)
-
     (slime-connect *localhost* port nil)
     (update-buffer-package)
     (setf *self-connected-port* port)))
@@ -1128,12 +1123,7 @@
   (let ((port (or (port-available-p *default-port*)
                   (random-port))))
     (run-swank-server command port :directory directory)
-
-    ;; workaround for windows
-    ;;  ('Thread not found: :REPL-THREAD' is returned from swank-server)
-    #+win32(sleep 2.0)
-    #-win32(sleep 0.5)
-
+    (sleep 0.5)
     (let ((successp)
           (condition))
       (loop :repeat 10

--- a/modes/lisp-mode/swank-protocol.lisp
+++ b/modes/lisp-mode/swank-protocol.lisp
@@ -235,11 +235,9 @@ to check if input is available."
 ;; workaround for windows
 ;;  (usocket:wait-for-input needs WSAResetEvent before call)
 #+(and sbcl win32)
-(progn
-  (sb-alien:define-alien-type ws-event sb-alien::hinstance)
-  (sb-alien:define-alien-routine ("WSAResetEvent" wsa-reset-event)
-      (boolean #.sb-vm::n-machine-word-bits)
-    (event-object ws-event)))
+(sb-alien:define-alien-routine ("WSAResetEvent" wsa-reset-event)
+    (boolean #.sb-vm::n-machine-word-bits)
+  (event-object usocket::ws-event))
 
 (defun message-waiting-p (connection &key (timeout 0))
   "t if there's a message in the connection waiting to be read, nil otherwise."

--- a/modes/lisp-mode/swank-protocol.lisp
+++ b/modes/lisp-mode/swank-protocol.lisp
@@ -247,9 +247,11 @@ to check if input is available."
   ;; workaround for windows
   ;;  (usocket:wait-for-input needs WSAResetEvent before call)
   #+(and sbcl win32)
-  (wsa-reset-event
-   (usocket::os-wait-list-%wait
-    (usocket::wait-list (connection-socket connection))))
+  (let ((socket (connection-socket connection)))
+    (when (usocket::wait-list socket)
+      (wsa-reset-event
+       (usocket::os-wait-list-%wait
+        (usocket::wait-list socket)))))
 
   (if (usocket:wait-for-input (connection-socket connection)
                               :ready-only t

--- a/modes/lisp-mode/util.lisp
+++ b/modes/lisp-mode/util.lisp
@@ -10,7 +10,7 @@
   (let (socket)
     (unwind-protect
          (handler-case (progn
-                         (setq socket (usocket:socket-listen "127.0.0.1" port :reuse-address t))
+                         (setq socket (usocket:socket-listen "127.0.0.1" port :reuse-address nil))
                          port)
            (usocket:address-in-use-error () nil)
            (usocket:socket-error (e)


### PR DESCRIPTION
Windows 上 で M-x slime を実行すると、固まったり、
応答が表示されなかったり、終了できなくなったりする件を、改善してみました。

- message-waiting-p ( modes/lisp-mode/swank-protocol.lisp )：
  Windows 版の sbcl では、
  usocket:wait-for-input を呼び出す前にイベントオブジェクトをリセットしないと、
  2回目以降の usocket:wait-for-input で、ウェイトしなくなってしまう。
  このため、WSAResetEvent でイベントオブジェクトをリセットするようにした。
  (本現象は、usocket:wait-for-input の引数にソケットを1個だけ指定したときに発生する。
  ソケットが1個だけのときは、内部情報 (wait-list) を毎回作らないで使いまわすようになっており、
  イベントオブジェクトも使いまわしになるためリセットが必要だった。。。
  https://github.com/usocket/usocket/blob/2b92b917cf9bd763492461b5b9814e801d1b063f/usocket.lisp#L348 )

- port-available-p ( modes/lisp-mode/util.lisp )：
  usocket:socket-listen のところで、
  :reuse-address t を指定しているが、
  複数プロセスが同一ポートで待ち受けして変になるケースがあったため、
  :reuse-address nil に変更した。

- start-thread ( modes/lisp-mode/lisp-mode.lisp )：
  - 前述の usocket:wait-for-input の対応の結果、
    #378 の (sleep 0.001) は不要になったため削除した。
  - change-connection 例外がいろいろな場所で発生することがあったため、
    handler-case の範囲を広げた。
  - message-waiting-p のタイムアウト値を 10 秒から 1 秒にへらした。
    (終了時に最大10秒固まったため)

- `add-hook *exit-editor-hook*` ( modes/lisp-mode/lisp-mode.lisp )：
  - ソケットクローズしないと終了しないことがあったため、
    ソケットクローズを追加した。
