### PR TITLE
Guard and display message for lisp-repl-mode

### DIFF
--- a/modes/lisp-mode/repl.lisp
+++ b/modes/lisp-mode/repl.lisp
@@ -4,10 +4,14 @@
     (:name "lisp-repl"
      :keymap *lisp-repl-mode-keymap*
      :syntax-table lem-lisp-syntax:*syntax-table*)
-  (repl-reset-input)
-  (lem.listener-mode:listener-mode t)
-  (setf *write-string-function* 'write-string-to-repl)
-  (setf (variable-value 'completion-spec) 'repl-completion))
+  (cond
+    ((eq (repl-buffer) (current-buffer))
+     (repl-reset-input)
+     (lem.listener-mode:listener-mode t)
+     (setf *write-string-function* 'write-string-to-repl)
+     (setf (variable-value 'completion-spec) 'repl-completion))
+    (t
+     (message "No connection for repl. Did you mean 'start-lisp-repl' command?"))))
 
 (defun read-string-thread-stack ()
   (buffer-value (repl-buffer) 'read-string-thread-stack))

--- a/modes/lisp-mode/repl.lisp
+++ b/modes/lisp-mode/repl.lisp
@@ -11,7 +11,7 @@
      (setf *write-string-function* 'write-string-to-repl)
      (setf (variable-value 'completion-spec) 'repl-completion))
     (t
-     (message "No connection for repl. Did you mean 'start-lisp-repl' command?"))))
+     (editor-error "No connection for repl. Did you mean 'start-lisp-repl' command?"))))
 
 (defun read-string-thread-stack ()
   (buffer-value (repl-buffer) 'read-string-thread-stack))


### PR DESCRIPTION
M-x start-lisp-repl と間違えて M-x lisp-repl-mode を実行すると、
Enter を押すたびにエラーが出る状態になってしまうので、
ガードしてメッセージを表示するようにしてみました。
