### PR TITLE
Fix multi-line string input in lisp-repl-mode

### DIFF
--- a/lib/base/syntax.lisp
+++ b/lib/base/syntax.lisp
@@ -26,7 +26,7 @@
           skip-symbol-backward
           symbol-string-at-point
           make-pps-state
-          pps-state-state-type
+          pps-state-type
           pps-state-token-start-point
           pps-state-end-char
           pps-state-block-comment-depth


### PR DESCRIPTION
lisp-repl-mode で、以下のような複数行の文字列を入力しようとすると、
エラーになる件を修正しました。
```
"123
456"
```
