### PR TITLE
Enable history function to backup/restore edit string

### DIFF
--- a/lib/core/history.lisp
+++ b/lib/core/history.lisp
@@ -5,7 +5,9 @@
            :add-history
            :prev-history
            :next-history
-           :previous-matching)
+           :previous-matching
+           :backup-edit-string
+           :restore-edit-string)
   #+sbcl
   (:lock t))
 (in-package :lem.history)
@@ -13,7 +15,8 @@
 (defstruct (history (:constructor %make-history))
   data
   index
-  novelty-check)
+  novelty-check
+  edit-string)
 
 (defun history-default-novelty-check (input last-input)
   (and (not (equal input last-input))
@@ -58,3 +61,20 @@
               (setf (history-index history) i)
               (return (values (aref (history-data history) i)
                               t)))))
+
+(defun backup-edit-string (history x)
+  (when (or (>= (history-index history)
+                (length (history-data history)))
+            (not (equal x
+                        (aref (history-data history)
+                              (history-index history)))))
+    (setf (history-edit-string history) x)
+    (setf (history-index history) (length (history-data history)))))
+
+(defun restore-edit-string (history)
+  (when (= (history-index history)
+           (1- (length (history-data history))))
+    (setf (history-index history) (length (history-data history)))
+    (values (history-edit-string history)
+            t)))
+

--- a/lib/core/minibuffer.lisp
+++ b/lib/core/minibuffer.lisp
@@ -211,7 +211,21 @@
                *minibuf-read-line-comp-f*
                start))))
 
+(defun %backup-edit-string (history)
+  (lem.history:backup-edit-string
+   history
+   (points-to-string (minibuffer-start-point)
+                     (buffer-end-point (minibuffer)))))
+
+(defun %restore-edit-string (history)
+  (multiple-value-bind (str win)
+      (lem.history:restore-edit-string history)
+    (when win
+      (minibuffer-clear-input)
+      (insert-string (current-point) str))))
+
 (define-command minibuffer-read-line-prev-history () ()
+  (%backup-edit-string *minibuf-read-line-history*)
   (multiple-value-bind (str win)
       (lem.history:prev-history *minibuf-read-line-history*)
     (when win
@@ -219,6 +233,8 @@
       (insert-string (current-point) str))))
 
 (define-command minibuffer-read-line-next-history () ()
+  (%backup-edit-string *minibuf-read-line-history*)
+  (%restore-edit-string *minibuf-read-line-history*)
   (multiple-value-bind (str win)
       (lem.history:next-history *minibuf-read-line-history*)
     (when win


### PR DESCRIPTION
ヒストリ機能使用中に、編集中の文字列を記憶しておき、元の表示に戻せるようにしました。

最新のヒストリを表示中に M-n を押すと、編集中の文字列の表示に戻します。

例えば、REPL に 12345 まで入力して、M-p でヒストリを呼び出すと、
12345 は消えますが、M-n を繰り返すことで 12345 の表示に戻せます。

ただし、ヒストリを呼び出して編集した場合には、それが新しい編集中の文字列になります。
(古い編集中の文字列の情報は消えます。また、ヒストリデータ自身は変化しません)
