### PR TITLE
Fix buffer-package for non-standard package value

### DIFF
--- a/modes/lisp-mode/lisp-mode.lisp
+++ b/modes/lisp-mode/lisp-mode.lisp
@@ -138,10 +138,11 @@
     (self-connect)))
 
 (defun buffer-package (buffer &optional default)
-  (let ((package-name (buffer-value buffer "package")))
-    (or (ignore-errors (string-upcase package-name))
-        (ignore-errors (string-upcase (car package-name)))
-        default)))
+  (let ((package-name (buffer-value buffer "package" default)))
+    (if (symbolp package-name)
+        package-name
+        (or (ignore-errors (string-upcase package-name))
+            (ignore-errors (string-upcase (car package-name)))))))
 
 (defun (setf buffer-package) (package buffer)
   (setf (buffer-value buffer "package") package))

--- a/modes/lisp-mode/lisp-mode.lisp
+++ b/modes/lisp-mode/lisp-mode.lisp
@@ -140,7 +140,9 @@
 (defun buffer-package (buffer &optional default)
   (let ((package-name (buffer-value buffer "package")))
     (if package-name
-        (string-upcase package-name)
+        (or (ignore-errors (string-upcase package-name))
+            (ignore-errors (string-upcase (car package-name)))
+            default)
         default)))
 
 (defun (setf buffer-package) (package buffer)

--- a/modes/lisp-mode/lisp-mode.lisp
+++ b/modes/lisp-mode/lisp-mode.lisp
@@ -139,10 +139,8 @@
 
 (defun buffer-package (buffer &optional default)
   (let ((package-name (buffer-value buffer "package")))
-    (if package-name
-        (or (ignore-errors (string-upcase package-name))
-            (ignore-errors (string-upcase (car package-name)))
-            default)
+    (or (ignore-errors (string-upcase package-name))
+        (ignore-errors (string-upcase (car package-name)))
         default)))
 
 (defun (setf buffer-package) (package buffer)

--- a/modes/lisp-mode/lisp-mode.lisp
+++ b/modes/lisp-mode/lisp-mode.lisp
@@ -139,10 +139,12 @@
 
 (defun buffer-package (buffer &optional default)
   (let ((package-name (buffer-value buffer "package" default)))
-    (if (symbolp package-name)
-        package-name
-        (or (ignore-errors (string-upcase package-name))
-            (ignore-errors (string-upcase (car package-name)))))))
+    (typecase package-name
+      (null default)
+      ((or symbol string)
+       (string-upcase package-name))
+      ((cons (or symbol string))
+       (string-upcase (car package-name))))))
 
 (defun (setf buffer-package) (package buffer)
   (setf (buffer-value buffer "package") package))


### PR DESCRIPTION
If `(buffer-value buffer "package")` returned a value that was not
a string designator, and error was signaled and Lem died.
E.g. the file "iterate.lisp" from project `:iterate` contains the
following property list:
```
;;;-*- syntax:COMMON-LISP; Package: (ITERATE :use "COMMON-LISP" :colon-mode :external) -*-
```
Therefore, opening that file and calling `lisp-mode` killed Lem.
Now, wrap call with ignore-errors and use default if NIL is returned.