### PR TITLE
Complex indent method fix

### DIFF
--- a/lib/lisp-syntax/indent.lisp
+++ b/lib/lisp-syntax/indent.lisp
@@ -69,7 +69,9 @@
                         (malformed "&body is not the last element")))
                      ((&rest)
                       (unless (and (consp method-rest) (null (cdr method-rest)))
-                        (malformed "&rest must be followed by only one element")))
+                        (malformed "&rest must be followed by only one element"))
+                      (when (eq '&rest (car method-rest))
+                        (malformed "&rest cannot be followed by another &rest")))
                      ((&whole)
                       (malformed "&whole can only be the first element in a submethod"))
                      ((&lambda) nil)
@@ -421,7 +423,7 @@
               :if (eq method1 '&rest) :do
                  (cond
                    ((or (not (null (cdr method-rest)))           ; safety-check
-                        (member (car method-rest) '(&rest &body &whole)))
+                        (member (car method-rest) '(&rest &whole)))
                     (return-from exit 'default-indent))         ; malformed method
                    (t (setq method1 (car method-rest)
                             method-rest nil

--- a/lib/lisp-syntax/indent.lisp
+++ b/lib/lisp-syntax/indent.lisp
@@ -5,7 +5,8 @@
            :set-indentation
            :update-system-indentation
            :indentation-update
-           :calc-indent))
+           :calc-indent
+           :&lambda))
 (in-package :lem-lisp-syntax.indent)
 
 (defparameter *body-indent* 2)
@@ -75,7 +76,7 @@
         ("catch" 1)
         ("cond"        (&rest (&whole 2 &rest 1)))
         ("defvar"      (4 2 2))
-        ("defclass"    (6 4 (&whole 2 &rest 1) (&whole 2 &rest 1)))
+        ("defclass"    (6 (&whole 4 &rest 1) (&whole 2 &rest 1) (&whole 2 &rest 1)))
         ("defconstant" . "defvar")
         ("defcustom"   (4 2 2 2))
         ("defparameter" . "defvar")
@@ -100,7 +101,7 @@
         ;("do"          lisp-indent-do)
         ("do" 2)
         ("do*" . "do")
-        ("dolist"      1)
+        ("dolist"      ((&whole 4 2 1) &body))
         ("dotimes" . "dolist")
         ("eval-when"   1)
         ("flet"        ((&whole 4 &rest (&whole 1 &lambda &body)) &body))
@@ -151,7 +152,7 @@
         ("when" 1)
         ("with-accessors" . "multiple-value-bind")
         ("with-condition-restarts" . "multiple-value-bind")
-        ("with-compilation-unit" (&lambda &body))
+        ("with-compilation-unit" ((&whole 4 &rest 1) &body))
         ("with-output-to-string" (4 2))
         ("with-slots" . "multiple-value-bind")
         ("with-standard-io-syntax" (2))))
@@ -354,7 +355,10 @@
   (loop
     :named exit
     :for (n-start . pathrest) :on path
-    :if (zerop n-start) :do (return-from exit 'default-indent)
+    :if (zerop n-start) :do
+       (case (car method)
+         ((&rest) (setf n-start 1))
+         (t (return-from exit 'default-indent)))
     :finally (return-from exit 'default-indent)
     :do (loop :for (method1 . method-rest) :on method
               :for n :from (1- n-start) :downto 0

--- a/lib/lisp-syntax/indent.lisp
+++ b/lib/lisp-syntax/indent.lisp
@@ -412,12 +412,15 @@
 (defun compute-indent-complex-method (method path indent-point sexp-column)
   (loop
     :named exit
-    :for (n-start* . pathrest) :on path
-    :for n-start := (1- n-start*) :then n-start*
+    :for (n-start . pathrest) :on path
     :finally (return-from exit 'default-indent)
+    :if (and (= n-start 0)
+             (eq '&rest (car method))
+             (consp (cadr method))) :do
+       (setq n-start 1)
     :do (loop :with restp := nil
               :for (method1 . method-rest) :on method
-              :for n :from n-start :downto 0
+              :for n :from (1- n-start) :downto 0
               :if (eq method1 '&rest) :do
                  (setq method1 (car method-rest)
                        method-rest nil


### PR DESCRIPTION
Lem didn't correctly indent Lisp forms whenever the
method registered for a symbol ended in `&rest <integer>.
For instance, `multiple-value-bind` was indented like that:
```
  (multiple-value-bind (a b
                          c d
                          e f)
      g
    h)
```
However, it should be:
```
  (multiple-value-bind (a b
                        c d
                        e f)
      g
    h)
```

I also added an error-check before setting some Lisp indentation method. Tested error checking all methods both in static and dynamic tables, no error was found. Indentations now is like Emacs in all tests I made.