### PR TITLE
Added commands to show information about current mode and all available modes

### DIFF
--- a/lib/core/help-command.lisp
+++ b/lib/core/help-command.lisp
@@ -72,7 +72,7 @@
                            (mode-description mode))))
                (format s "~2%")))
         (print-modes "Major modes" major-modes)
-        (print-modes "Minor modes" minor-modes))))))
+        (print-modes "Minor modes" minor-modes)))))
 
 ;; Unable to use this binding because C-h is used by 'delete-previous-char
 ;; (define-key *global-keymap* "C-h m" 'describe-mode)

--- a/lib/core/help-command.lisp
+++ b/lib/core/help-command.lisp
@@ -6,6 +6,8 @@
           apropos-command))
 
 (define-key *global-keymap* "C-x ?" 'describe-key)
+;; Unable to use this binding because C-h is used by 'delete-previous-char
+;; (define-key *global-keymap* "C-h k" 'describe-key)
 (define-command describe-key () ()
   (message "describe-key: ")
   (redraw-display)
@@ -34,6 +36,8 @@
                                       (symbol-name command))))))
     (terpri s)))
 
+;; Unable to use this binding because C-h is used by 'delete-previous-char
+;; (define-key *global-keymap* "C-h b" 'describe-bindings)
 (define-command describe-bindings () ()
   (let ((buffer (current-buffer)))
     (with-pop-up-typeout-window (s (make-buffer "*bindings*") :focus t :erase t)
@@ -48,6 +52,45 @@
         (describe-bindings-internal s
                                     (mode-name mode)
                                     (mode-keymap mode))))))
+
+(define-command list-modes () ()
+  "Outputs all available major and minor modes."
+  (with-pop-up-typeout-window (s (make-buffer "*all-modes*") :focus t :erase t)
+    (let ((major-modes (remove-if-not #'is-major *mode-list*))
+          (minor-modes (remove-if #'is-major *mode-list*)))
+      (labels ((is-technical-mode (mode)
+               (eql (elt (symbol-name mode) 0)
+                    #\%))
+             (print-modes (title modes)
+               (format s "~A:~2%" title)
+               ;; Remove technical modes where name starts with %
+               (let* ((modes (remove-if #'is-technical-mode modes))
+                     (sorted-modes (sort modes #'string< :key #'string-downcase)))
+                 (dolist (mode sorted-modes)
+                   (format s "* ~A~@[ – ~A~]~%"
+                           (mode-name mode)
+                           (mode-description mode))))
+               (format s "~2%")))
+        (print-modes "Major modes" major-modes)
+        (print-modes "Minor modes" minor-modes))))))
+
+;; Unable to use this binding because C-h is used by 'delete-previous-char
+;; (define-key *global-keymap* "C-h m" 'describe-mode)
+(define-command describe-mode () ()
+  "Show information about current major mode and enabled minor modes."
+  (let* ((buffer (current-buffer))
+         (major-mode (buffer-major-mode buffer))
+         (minor-modes (buffer-minor-modes buffer)))
+    (with-pop-up-typeout-window (s (make-buffer "*modes*") :focus t :erase t)
+      (format s "Major mode is: ~A~@[ – ~A~]~%"
+              (mode-name major-mode)
+              (mode-description major-mode))
+      (when minor-modes
+        (format s "~2&Minor modes:~2%")
+        (dolist (mode minor-modes)
+          (format s "* ~A~@[ – ~A~]~%"
+                  (mode-name mode)
+                  (mode-description mode)))))))
 
 (define-key *global-keymap* "M-x" 'execute-command)
 (define-command execute-command (arg) ("P")

--- a/lib/core/language-mode.lisp
+++ b/lib/core/language-mode.lisp
@@ -54,7 +54,8 @@
     (funcall fn)))
 
 (define-major-mode language-mode ()
-    (:keymap *language-mode-keymap*)
+    (:name "language"
+     :keymap *language-mode-keymap*)
   (when (or (null *idle-timer*)
             (not (timer-alive-p *idle-timer*)))
     (setf *idle-timer*

--- a/modes/lisp-mode/lisp-mode.lisp
+++ b/modes/lisp-mode/lisp-mode.lisp
@@ -22,6 +22,7 @@
 
 (define-major-mode lisp-mode language-mode
     (:name "lisp"
+     :description "Contains necessary functions to handle lisp code."
      :keymap *lisp-mode-keymap*
      :syntax-table lem-lisp-syntax:*syntax-table*)
   (modeline-add-status-list (lambda (window)

--- a/modes/paredit-mode/paredit-mode.lisp
+++ b/modes/paredit-mode/paredit-mode.lisp
@@ -25,6 +25,7 @@ link : http://www.daregada.sakuraweb.com/paredit_tutorial_ja.html
 
 (define-minor-mode paredit-mode
     (:name "paredit"
+     :description "Helps to handle parentheses balanced in your Lisp code."
      :keymap *paredit-mode-keymap*))
 
 (defun move-to-word-end (q)


### PR DESCRIPTION
* list-modes - shows all available modes;
* describe-mode - shows current major mode and enabled minor modes.

Also, each mode now can have a human-readable description and an attribute to distinguish major mode from a minor. You can call
function `is-major` on a symbol, to check if it is a major mode.