### PR TITLE
Add native GitHub "Sponsor" button linking to Open Collective account

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+open_collective: lem


### PR DESCRIPTION
Simply merge this pull request and activate the "Sponsorships" option in lem's project settings to get a cute little "Sponsor" button linking to your [Open Collective account](https://opencollective.com/lem)!

Here's a [preview](https://github.com/Hexstream/lem) of the end result.

Here's the [official documentation](https://help.github.com/en/articles/displaying-a-sponsor-button-in-your-repository) for this nice feature.

(Note that you do not need to be sponsored by GitHub to use this feature.)