### PR TITLE
Fix completion for filenames inside "~"

### DIFF
--- a/lib/base/fileutil.lisp
+++ b/lib/base/fileutil.lisp
@@ -39,7 +39,7 @@
                         ((string= name "..")
                          (setf path (butlast path)))
                         ((string= name "~")
-                         (setf path (pathname-directory "~/")))
+                         (setf path (pathname-directory (truename "~/"))))
                         ((string= name "")
                          (setf path (list :absolute)))
                         (t


### PR DESCRIPTION
On SBCL Linux, `(pathname-directory "~/")` returns `(:absolute :home)`,
which `completion-file` don't handle properly.