### PR TITLE
Prompt for directory creation when it does not exist

### DIFF
--- a/lib/core/file-command.lisp
+++ b/lib/core/file-command.lisp
@@ -12,8 +12,21 @@
           revert-buffer
           change-directory))
 
+
 (defun expand-files* (filename)
   (directory-files (expand-file-name filename (buffer-directory))))
+
+(defun maybe-create-directory (directory)
+  (when (prompt-for-y-or-n-p
+         (format nil "Directory does not exist: ~A. Create" directory))
+    (ensure-directories-exist directory)))
+
+(defun directory-for-file-or-lose (filename)
+  (let ((directory (directory-namestring filename)))
+    (unless (or (uiop:directory-exists-p directory)
+                (maybe-create-directory directory))
+      (error 'editor-abort))
+    directory))
 
 (define-key *global-keymap* "C-x C-f" 'find-file)
 (define-command find-file (filename) ("p")
@@ -40,8 +53,9 @@
           ((pathnamep filename)
            (setf filename (namestring filename))))
     (dolist (pathname (expand-files* filename))
-      (switch-to-buffer (find-file-buffer pathname) t nil))
-    t))
+      (directory-for-file-or-lose pathname)
+      (switch-to-buffer (find-file-buffer pathname) t nil)
+      t)))
 
 (define-key *global-keymap* "C-x C-r" 'read-file)
 (define-command read-file (filename) ("FRead File: ")
@@ -87,11 +101,9 @@
                  (not (prompt-for-y-or-n-p (format nil
                                                    "~a is opend, overwrite it?"
                                                    expand-file-name))))
+      (directory-for-file-or-lose filename)
       (unless (string= old new)
-        (buffer-rename (current-buffer)
-                       (if (get-buffer new)
-                           (uniq-buffer-name new)
-                           new)))
+        (buffer-rename (current-buffer) (new-buffer-name name expand-file-name)))
       (setf (buffer-filename) expand-file-name)
       (add-newline-at-eof (current-buffer))
       (save-buffer t))))


### PR DESCRIPTION
When openning a file in an non-existing directory `find-file`
and `read-file` ask the user if the directory should be
created before opening the file, aborting when the user
responds 'n'.