### PR TITLE
Make escape-delay configurable

### DIFF
--- a/frontends/ncurses/ncurses.lisp
+++ b/frontends/ncurses/ncurses.lisp
@@ -4,6 +4,8 @@
            :input-polling-interval))
 (in-package :lem-ncurses)
 
+(define-editor-variable escape-delay 100)
+
 (defclass ncurses (lem:implementation)
   ()
   (:default-initargs
@@ -312,7 +314,7 @@
                 ((= code resize-code) :resize)
                 ((= code abort-code) :abort)
                 ((= code escape-code)
-                 (charms/ll:timeout 200)
+                 (charms/ll:timeout (variable-value 'escape-delay))
                  (let ((code (prog1 (charms/ll:getch)
                                (charms/ll:timeout -1))))
                    (cond ((= code -1)


### PR DESCRIPTION
This is a my first PR for lem.

---

https://github.com/cxxxr/lem/issues/287

I felt the behavior of lem is slower than vim, too.
I added configurable variable for escape delay.

Default value `100` is taken from vim. c.f. https://vim-jp.org/vimdoc-ja/options.html#'ttimeoutlen'