### PR TITLE
[scheme-mode] Add scheme slime function connecting to r7rs-swank

### DIFF
--- a/modes/scheme-mode/errors.lisp
+++ b/modes/scheme-mode/errors.lisp
@@ -1,0 +1,11 @@
+(defpackage :lem-scheme-mode.errors
+  (:use :cl)
+  (:export :disconnected
+           :change-connection))
+(in-package :lem-scheme-mode.errors)
+
+(define-condition disconnected (simple-condition)
+  ())
+
+(define-condition change-connection (simple-condition)
+  ())

--- a/modes/scheme-mode/eval.lisp
+++ b/modes/scheme-mode/eval.lisp
@@ -3,11 +3,12 @@
 (defvar *scheme-process* nil)
 (defvar *newline-delay-flag* nil)
 
-(defun scheme-process-buffer ()
+(defun scheme-process-buffer (&key (auto-make t))
   (or (get-buffer "*scheme-process*")
-      (let ((buffer (make-buffer "*scheme-process*")))
-        (change-buffer-mode buffer 'scheme-repl-mode)
-        buffer)))
+      (when auto-make
+        (let ((buffer (make-buffer "*scheme-process*")))
+          (change-buffer-mode buffer 'scheme-repl-mode)
+          buffer))))
 
 (defun scheme-output-string (string)
   (let ((buffer (scheme-process-buffer)))
@@ -31,11 +32,10 @@
 (defun scheme-run-process ()
   (when (and *scheme-process*
              (not (lem-process:process-alive-p *scheme-process*)))
-    (let ((buffer (scheme-process-buffer)))
-      (scheme-output-string
-       (format nil "~%;; Scheme process was aborted. Restarting...~%~%"))
-      (lem-process:delete-process *scheme-process*)
-      (setf *scheme-process* nil)))
+    (scheme-output-string
+     (format nil "~%;; Scheme process was aborted. Restarting...~%~%"))
+    (lem-process:delete-process *scheme-process*)
+    (setf *scheme-process* nil))
   (cond
     ((not *scheme-process*)
      (setf *scheme-process* (lem-process:run-process
@@ -64,18 +64,6 @@
 (defun scheme-send-input (string)
   (lem-process:process-send-input *scheme-process*
                                   (format nil "~A~%" string)))
-
-(define-command scheme-eval-last-expression (p) ("P")
-  (declare (ignore p))
-  (with-point ((start (current-point))
-               (end   (current-point)))
-    (form-offset start -1)
-    (scheme-run-process-and-output-newline)
-    (scheme-send-input (points-to-string start end))))
-
-(define-command scheme-eval-region (start end) ("r")
-  (scheme-run-process-and-output-newline)
-  (scheme-send-input (points-to-string start end)))
 
 (add-hook *exit-editor-hook*
           (lambda ()

--- a/modes/scheme-mode/lem-scheme-mode.asd
+++ b/modes/scheme-mode/lem-scheme-mode.asd
@@ -1,5 +1,8 @@
 (defsystem "lem-scheme-mode"
   :depends-on ("alexandria"
+               "trivial-types"
+               "usocket"
+               "optima"
                "uiop"
                #+#.(cl:if (asdf:find-system :async-process cl:nil) '(and) '(or)) "lem-process"
                "lem-core")
@@ -8,11 +11,15 @@
                (:file "syntax-indent")
                (:file "syntax-syntax-table")
                (:file "syntax-misc")
+               (:file "syntax-parse")
                (:file "lem-scheme-syntax")
+               (:file "util")
+               (:file "errors")
+               (:file "swank-protocol")
                (:file "package")
                (:file "grammer")
                (:file "scheme-mode")
+               (:file "swank-connection")
                #+#.(cl:if (asdf:find-system :async-process cl:nil) '(and) '(or))
                (:file "eval")
-               #+#.(cl:if (asdf:find-system :async-process cl:nil) '(and) '(or))
                (:file "repl")))

--- a/modes/scheme-mode/lem-scheme-syntax.lisp
+++ b/modes/scheme-mode/lem-scheme-syntax.lisp
@@ -4,4 +4,5 @@
    :lem-scheme-syntax.data
    :lem-scheme-syntax.indent
    :lem-scheme-syntax.syntax-table
-   :lem-scheme-syntax.misc))
+   :lem-scheme-syntax.misc
+   :lem-scheme-syntax.parse))

--- a/modes/scheme-mode/package.lisp
+++ b/modes/scheme-mode/package.lisp
@@ -2,26 +2,38 @@
   (:use :cl
         :lem
         :lem.completion-mode
-        :lem.language-mode)
+        :lem.language-mode
+        :lem-scheme-mode.errors
+        :lem-scheme-mode.swank-protocol
+        :lem-scheme-mode.util)
   (:export
    ;; scheme-mode.lisp
+   :scheme-mode
    :*scheme-mode-keymap*
    :*scheme-mode-hook*
    :*scheme-run-command*
    :*scheme-load-command*
+   :*use-scheme-slime*
+   :*scheme-swank-server-run-command*
    :*scheme-completion-names*
    :scheme-keyword-data
    :scheme-beginning-of-defun
    :scheme-end-of-defun
    :scheme-indent-sexp
-   :scheme-load-file
+   ;; swank-connection
+   :scheme-slime-connect
+   :scheme-slime
    ;; eval.lisp
    :scheme-kill-process
-   :scheme-eval-last-expression
-   :scheme-eval-region
    ;; repl.lisp
    :scheme-repl-mode
+   :scheme-repl-input-mode
    :*scheme-repl-mode-keymap*
+   :*scheme-repl-input-mode-keymap*
    :start-scheme-repl
    :scheme-switch-to-repl-buffer
-   :scheme-eval-or-newline))
+   :scheme-eval-or-newline
+   :scheme-eval-last-expression
+   :scheme-eval-region
+   :scheme-load-file
+   :scheme-repl-shortcut))

--- a/modes/scheme-mode/repl.lisp
+++ b/modes/scheme-mode/repl.lisp
@@ -4,17 +4,21 @@
     (:name "scheme-repl"
      :keymap *scheme-repl-mode-keymap*)
   (cond
-    ((eq (scheme-process-buffer) (current-buffer))
-     (setf (variable-value 'enable-syntax-highlight) nil)
+    ((or (eq (scheme-repl-type :kind :current) :scheme-process)
+         (eq (scheme-repl-type :kind :current) :scheme-slime))
      (lem.listener-mode:listener-mode t)
      (lem.listener-mode:listener-update-point)
-     ;; disable listener-mode functions
-     (setf (variable-value 'lem.listener-mode:listener-set-prompt-function)
-           (lambda (point) point)
-           (variable-value 'lem.listener-mode:listener-check-input-function)
-           (lambda (point))
-           (variable-value 'lem.listener-mode:listener-execute-function)
-           (lambda (point string)))
+     (when (eq (scheme-repl-type :kind :current) :scheme-process)
+       ;; disable listener-mode functions
+       (setf (variable-value 'lem.listener-mode:listener-set-prompt-function)
+             #'(lambda (point) point)
+             (variable-value 'lem.listener-mode:listener-check-input-function)
+             #'(lambda (point) (declare (ignore point)))
+             (variable-value 'lem.listener-mode:listener-execute-function)
+             #'(lambda (point string) (declare (ignore point string)))))
+     (repl-reset-input)
+     (setf *write-string-function* 'write-string-to-repl)
+     (setf (variable-value 'completion-spec) 'repl-completion)
      ;; overwrite listener-mode keymap
      (scheme-repl-input-mode t))
     (t
@@ -25,16 +29,52 @@
      :keymap *scheme-repl-input-mode-keymap*))
 (define-key *scheme-repl-input-mode-keymap* "Return" 'scheme-eval-or-newline)
 
+(defun scheme-repl-type (&key kind)
+  "Return scheme repl type, which is :scheme-slime or :scheme-process."
+  (case kind
+    ((:initial)
+     (cond
+       ((connected-p)
+        :scheme-slime)
+       ((boundp '*scheme-process*)
+        :scheme-process)))
+    ((:current)
+     (cond
+       ((eq (repl-buffer) (current-buffer))
+        :scheme-slime)
+       ((and (boundp '*scheme-process*)
+             (eq (scheme-process-buffer :auto-make nil) (current-buffer)))
+        :scheme-process)))
+    (t
+     (cond
+       ((repl-buffer)
+        :scheme-slime)
+       ((and (boundp '*scheme-process*)
+             (scheme-process-buffer :auto-make nil))
+        :scheme-process)))))
+
 (define-command start-scheme-repl () ()
-  (scheme-run-process)
-  (setf (current-window) (pop-to-buffer (scheme-process-buffer))))
+  (case (scheme-repl-type :kind :initial)
+    ((:scheme-slime)
+     (lem.listener-mode:listener-start "*scheme-repl*" 'scheme-repl-mode))
+    ((:scheme-process)
+     (scheme-run-process)
+     (setf (current-window) (pop-to-buffer (scheme-process-buffer))))
+    (t
+     (editor-error "Scheme repl is not available."))))
 
 (define-command scheme-switch-to-repl-buffer () ()
-  (start-scheme-repl))
+  (let ((buffer (repl-buffer)))
+    (if buffer
+        (setf (current-window) (pop-to-buffer buffer))
+        (start-scheme-repl))))
 
 (define-command scheme-eval-or-newline () ()
   (cond
-    ((and (eq (scheme-process-buffer) (current-buffer))
+    ((eq (scheme-repl-type :kind :current) :scheme-slime)
+     (check-connection)
+     (lem.listener-mode:listener-return))
+    ((and (eq (scheme-repl-type :kind :current) :scheme-process)
           (point<= (lem.listener-mode::listener-start-point (current-buffer))
                    (current-point))
           (repl-paren-correspond-p (current-point)))
@@ -55,3 +95,401 @@
                         '(:string :fence :block-string :block-comment)))
            (>= 0 (pps-state-paren-depth state))))))
 
+(define-command scheme-eval-last-expression (p) ("P")
+  (declare (ignore p))
+  (cond
+    ((eq (scheme-repl-type) :scheme-slime)
+     (check-connection)
+     (with-point ((start (current-point))
+                  (end (current-point)))
+       (form-offset start -1)
+       (run-hooks (variable-value 'before-eval-functions) start end)
+       (let ((string (points-to-string start end)))
+         ;(if p
+         ;    (eval-print string (- (window-width (current-window)) 2))
+         ;    (interactive-eval string))
+         (repl-eval nil string)
+         )))
+    ((eq (scheme-repl-type :kind :initial) :scheme-process)
+     (with-point ((start (current-point))
+                  (end   (current-point)))
+       (form-offset start -1)
+       (scheme-run-process-and-output-newline)
+       (scheme-send-input (points-to-string start end))))
+    (t
+     (editor-error "Scheme repl is not available."))))
+
+(define-command scheme-eval-region (start end) ("r")
+  (cond
+    ((eq (scheme-repl-type) :scheme-slime)
+     (check-connection)
+     ;(eval-with-transcript
+     ; `(swank:interactive-eval-region
+     ;   ,(points-to-string start end)))
+     (repl-eval nil (points-to-string start end))
+     )
+    ((eq (scheme-repl-type :kind :initial) :scheme-process)
+     (scheme-run-process-and-output-newline)
+     (scheme-send-input (points-to-string start end)))
+    (t
+     (editor-error "Scheme repl is not available."))))
+
+(define-command scheme-load-file (filename)
+    ((list (prompt-for-file "Load File: " (or (buffer-filename) (buffer-directory)) nil t)))
+  (cond
+    ((eq (scheme-repl-type) :scheme-slime)
+     (check-connection)
+     (when (and (probe-file filename)
+                (not (uiop:directory-pathname-p filename)))
+       (run-hooks (variable-value 'load-file-functions) filename)
+       ;(interactive-eval
+       ; (prin1-to-string
+       ;  `(if (and (find-package :roswell)
+       ;            (find-symbol (string :load) :roswell))
+       ;       (uiop:symbol-call :roswell :load ,filename)
+       ;       (swank:load-file ,filename))))
+       (scheme-eval-from-string
+        (format nil "(swank:load-file ~S)" filename))
+       ))
+    ((eq (scheme-repl-type :kind :initial) :scheme-process)
+     (scheme-run-process-and-output-newline)
+     (when (and (probe-file filename)
+                (not (uiop:directory-pathname-p filename)))
+       (scheme-send-input (format nil "(~a \"~a\")" *scheme-load-command* filename))))
+    (t
+     (editor-error "Scheme repl is not available."))))
+
+
+;; from lisp-mode/repl.lisp
+
+(defun read-string-thread-stack ()
+  (buffer-value (repl-buffer) 'read-string-thread-stack))
+
+(defun (setf read-string-thread-stack) (val)
+  (setf (buffer-value (repl-buffer) 'read-string-thread-stack) val))
+
+(defun read-string-tag-stack ()
+  (buffer-value (repl-buffer) 'read-string-tag-stack))
+
+(defun (setf read-string-tag-stack) (val)
+  (setf (buffer-value (repl-buffer) 'read-string-tag-stack) val))
+
+(define-key *scheme-repl-mode-keymap* "C-c C-c" 'scheme-repl-interrupt)
+(define-key *scheme-repl-mode-keymap* "," 'scheme-repl-shortcut)
+
+(define-command scheme-repl-interrupt () ()
+  (check-connection)
+  (send-message-string *connection*
+                       (format nil "(:emacs-interrupt ~(~S~))"
+                               (or (car (read-string-thread-stack))
+                                   :repl-thread))))
+
+(defvar *scheme-repl-shortcuts* '())
+
+(defun prompt-for-shortcuts ()
+  (let* ((*scheme-repl-shortcuts* *scheme-repl-shortcuts*)
+         (names (mapcar #'car *scheme-repl-shortcuts*)))
+    (cdr (assoc (prompt-for-line
+                 "Command:"
+                 ""
+                 (lambda (x) (completion-strings x names))
+                 (lambda (name) (member name names :test #'string=))
+                 'mh-scheme-repl-shortcuts)
+                *scheme-repl-shortcuts* :test #'equal))))
+
+(define-command scheme-repl-shortcut (n) ("p")
+  (with-point ((point (current-point)))
+    (if (point>= (lem.listener-mode::listener-start-point (current-buffer)) point)
+        (let ((fun (prompt-for-shortcuts)))
+          (when fun
+            (funcall fun n)))
+        (let ((c (insertion-key-p (last-read-key-sequence))))
+          (insert-character point c n)))))
+
+(defmacro define-repl-shortcut (name lambda-list &body body)
+  (if (symbolp lambda-list)
+      `(progn
+         (setf *scheme-repl-shortcuts* (remove ,(string-downcase name) *scheme-repl-shortcuts* :key 'first :test 'equal))
+         (push (cons ,(string-downcase name) ',lambda-list) *scheme-repl-shortcuts*)
+         ',name)
+      `(progn
+         (setf *scheme-repl-shortcuts* (remove ,(string-downcase name) *scheme-repl-shortcuts* :key 'first :test 'equal))
+         (push (cons ,(string-downcase name) ',name) *scheme-repl-shortcuts*)
+         (defun ,name ,lambda-list ,@body))))
+
+(defun repl-buffer ()
+  (get-buffer "*scheme-repl*"))
+
+(defun repl-set-prompt (point)
+  (insert-string point
+                 (format nil "~A> " (connection-prompt-string *connection*)))
+  point)
+
+(defun repl-reset-input ()
+  (let ((buffer (repl-buffer)))
+    (when buffer
+      (setf (variable-value 'lem.listener-mode:listener-set-prompt-function :buffer buffer)
+            'repl-set-prompt
+            (variable-value 'lem.listener-mode:listener-check-input-function :buffer buffer)
+            'repl-paren-correspond-p
+            (variable-value 'lem.listener-mode:listener-execute-function :buffer buffer)
+            'repl-eval))))
+
+(defun repl-change-read-line-input ()
+  (setf (variable-value 'lem.listener-mode:listener-set-prompt-function)
+        #'identity
+        (variable-value 'lem.listener-mode:listener-check-input-function)
+        (constantly t)
+        (variable-value 'lem.listener-mode:listener-execute-function)
+        'repl-read-line))
+
+(defun clear-repl ()
+  (lem.listener-mode:clear-listener (repl-buffer)))
+
+(defun get-repl-window ()
+  (let* ((buffer (repl-buffer)))
+    (if (eq buffer (window-buffer (current-window)))
+        (current-window)
+        (first (get-buffer-windows buffer)))))
+
+(defun repl-buffer-width ()
+  (alexandria:when-let* ((window (get-repl-window))
+                         (width (- (window-width window) 2)))
+    width))
+
+(defun repl-highlight-notes (notes)
+  (let ((buffer (repl-buffer)))
+    (dolist (note notes)
+      (optima:match note
+        ((and (optima:property :location location)
+              (optima:property :message _))
+         (let* ((xref-loc (source-location-to-xref-location location))
+                (offset (xref-location-position xref-loc)))
+           (with-point ((start (buffer-point buffer)))
+             (move-point start (lem.listener-mode::listener-start-point buffer))
+             (form-offset start -1)
+             (character-offset start (if (plusp offset) (1- offset) offset))
+             (with-point ((end start))
+               (form-offset end 1)
+               (put-text-property start end :attribute 'compiler-note-attribute)))))))))
+
+(defun repl-completion (point)
+  (with-point ((p point))
+    (cond ((maybe-beginning-of-string p)
+           (character-offset p 1)
+           (let ((str (points-to-string p point)))
+             (mapcar (lambda (filename)
+                       (make-completion-item :label filename
+                                             :start p
+                                             :end point))
+                     (completion-file str (lem:buffer-directory (point-buffer p))))))
+          (t
+           (completion-symbol p)))))
+
+(defvar *repl-compiler-check* nil)
+
+(defvar *repl-temporary-file*
+  (merge-pathnames "scheme-slime-repl.tmp" (uiop:temporary-directory)))
+
+(defun repl-eval (point string)
+  (declare (ignore point))
+  (check-connection)
+  (cond
+    (*repl-compiler-check*
+     (with-open-file (stream *repl-temporary-file*
+                             :direction :output
+                             :if-exists :supersede
+                             :if-does-not-exist :create)
+       (write-string string stream))
+     (let ((result
+             (let ((*write-string-function* (constantly nil)))
+               (scheme-eval `(swank:compile-file-for-emacs *repl-temporary-file* nil)))))
+       (destructuring-bind (notes successp duration loadp fastfile)
+           (cdr result)
+         (declare (ignore successp duration loadp fastfile))
+         (repl-highlight-notes notes)
+         (listener-eval string))))
+    (t
+     (listener-eval string))))
+
+(defparameter *record-history-of-repl* nil)
+(defvar *repl-history* '())
+
+(defun listener-eval (string)
+
+  ;; for r7rs-swank (suppress useless return value)
+  (when (string= (string-trim '(#\space #\tab) string) "")
+    (setf string "(values)"))
+
+  (request-listener-eval
+   *connection*
+   string
+   (lambda (value)
+     (declare (ignore value))
+     (lem.listener-mode:listener-reset-prompt (repl-buffer))
+     (when *record-history-of-repl*
+       (start-timer 0 nil
+                    (lambda ()
+                      (when (position-if (complement #'syntax-space-char-p) string)
+                        (push (cons string (scheme-eval-from-string "CL:/" "CL"))
+                              *repl-history*))))))
+   ;(repl-buffer-width)
+   ))
+
+(defun repl-read-string (thread tag)
+  (unless (repl-buffer) (start-scheme-repl))
+  (let ((buffer (repl-buffer)))
+    (push thread (read-string-thread-stack))
+    (push tag (read-string-tag-stack))
+    (setf (current-window) (pop-to-buffer buffer))
+    (buffer-end (current-point))
+    (lem.listener-mode:listener-update-point)
+    (repl-change-read-line-input)))
+
+(defun repl-pop-stack ()
+  (let ((thread (pop (read-string-thread-stack)))
+        (tag (pop (read-string-tag-stack))))
+    (when (null (read-string-thread-stack))
+      (repl-reset-input))
+    (values thread tag)))
+
+(defun repl-abort-read (thread tag)
+  (declare (ignore thread tag))
+  (repl-pop-stack)
+  (message "Read aborted"))
+
+(defun repl-read-line (point string)
+  (declare (ignore point))
+  (multiple-value-bind (thread tag) (repl-pop-stack)
+    (dispatch-message (list :emacs-return-string
+                            thread
+                            tag
+                            (concatenate 'string
+                                         string
+                                         (string #\newline))))))
+
+(defun write-string-to-repl (string)
+  (let ((buffer (repl-buffer)))
+    (unless buffer
+      (start-scheme-repl)
+      (setf buffer (repl-buffer)))
+    (with-point ((start (buffer-end-point buffer) :left-inserting))
+      (when (text-property-at start :field -1)
+        (insert-character start #\newline))
+      (insert-escape-sequence-string (buffer-end-point buffer) string))
+    (lem.listener-mode:listener-update-point (buffer-end-point buffer))
+    (buffer-end (buffer-point buffer))
+    (alexandria:when-let ((window (get-repl-window)))
+      (with-current-window window
+        (buffer-end (buffer-point buffer))
+        (window-see window)))))
+
+(defvar *escape-sequence-argument-specs*
+  '(("0" :bold-p nil :reverse-p nil :underline-p nil)
+    ("1" :bold-p t)
+    ("2")
+    ("4" :underline-p t)
+    ("5")
+    ("7" :reverse-p t)
+    ("8")
+    ("22" :bold-p nil)
+    ("24" :underline-p nil)
+    ("25")
+    ("27" :reverse-p nil)
+    ("28")
+
+    ("30" :foreground "black")
+    ("31" :foreground "red")
+    ("32" :foreground "green")
+    ("33" :foreground "yellow")
+    ("34" :foreground "blue")
+    ("35" :foreground "magenta")
+    ("36" :foreground "cyan")
+    ("37" :foreground "white")
+
+    ("40" :background "black")
+    ("41" :background "red")
+    ("42" :background "green")
+    ("43" :background "yellow")
+    ("44" :background "blue")
+    ("45" :background "magenta")
+    ("46" :background "cyan")
+    ("47" :background "white")
+
+    ("90" :foreground "dim gray")
+    ("91" :foreground "red")
+    ("92" :foreground "green")
+    ("93" :foreground "yello")
+    ("94" :foreground "royalblue")
+    ("95" :foreground "darkorchid1")
+    ("96" :foreground "cyan1")
+    ("97" :foreground "white")
+
+    ("100" :background "dim gray")
+    ("101" :background "red")
+    ("102" :background "green")
+    ("103" :background "yello")
+    ("104" :background "royalblue")
+    ("105" :background "darkorchid1")
+    ("106" :background "cyan1")
+    ("107" :background "white")))
+
+(defun raw-seq-to-attribute (string)
+  (let ((arguments (uiop:split-string string :separator '(#\;)))
+        (attribute-parameters '()))
+    (dolist (argument arguments)
+      (alexandria:when-let (spec (assoc argument *escape-sequence-argument-specs*
+                                        :test #'string=))
+        (loop :for (key value) :on (rest spec) :by #'cddr
+              :do (setf (getf attribute-parameters key) value))))
+    (apply #'make-attribute attribute-parameters)))
+
+(defun split-escape-sequence-string (string)
+  (let ((acc '())
+        (pos 0))
+    (loop
+      (multiple-value-bind (start end reg-starts reg-ends)
+          (ppcre:scan "\\e\\[([^m]*)m" string :start pos)
+        (unless (and start end reg-starts reg-ends) (return))
+        (unless (= pos start)
+          (push (subseq string pos start) acc))
+        (push (raw-seq-to-attribute
+               (subseq string
+                       (aref reg-starts 0)
+                       (aref reg-ends 0)))
+              acc)
+        (setf pos end)))
+    (push (subseq string pos) acc)
+    (nreverse acc)))
+
+(defun parse-escape-sequence (string)
+  (split-escape-sequence-string string))
+
+(defun insert-escape-sequence-string (point string)
+  (let ((tokens (parse-escape-sequence string))
+        (current-attribute nil))
+    (dolist (token tokens)
+      (etypecase token
+        (null
+         (setf current-attribute nil))
+        (attribute
+         (setf current-attribute token))
+        (string
+         (insert-string point token :attribute current-attribute))))))
+
+(define-repl-shortcut sayonara (n)
+  (declare (ignorable n))
+  ;(if (self-connection-p *connection*)
+  ;    (message "Can't say sayonara because it's self connection.")
+  ;    ;(interactive-eval "(swank:quit-lisp)")
+  ;    ;(scheme-eval-from-string "(swank:quit-lisp)")
+  ;    (interactive-eval "(exit)")
+  ;    ))
+  (case (scheme-repl-type)
+    ((:scheme-slime)
+     (check-connection)
+     (scheme-slime-quit))
+    ((:scheme-process)
+     (scheme-kill-process))
+    (t
+     (editor-error "Scheme repl is not available."))))

--- a/modes/scheme-mode/swank-connection.lisp
+++ b/modes/scheme-mode/swank-connection.lisp
@@ -1,0 +1,1101 @@
+(in-package :lem-scheme-mode)
+
+(define-editor-variable load-file-functions '())
+(define-editor-variable before-compile-functions '())
+(define-editor-variable before-eval-functions '())
+
+(define-attribute compilation-region-highlight
+  (t :background "orange"))
+
+(define-attribute evaluation-region-highlight
+  (t :background "green"))
+
+;(defparameter *default-port* 4005)
+(defparameter *default-port* 4006)
+(defparameter *localhost* "127.0.0.1")
+
+(defvar *connection-list* '())
+;(defvar *connection* nil) ; move to scheme-mode.lisp
+(defvar *event-hooks* '())
+(defvar *write-string-function* 'write-string-to-repl)
+(defvar *last-compilation-result* nil)
+;(defvar *indent-table* (make-hash-table :test 'equal))
+
+;; for r7rs-swank (suppress error display for autodoc)
+(defvar *suppress-error-disp* nil)
+
+;; debug log
+(defun dbg-log-format (fmt &rest args)
+  (with-open-file (out "lemlog_swankconn0001.txt"
+                       :direction :output
+                       :if-does-not-exist :create
+                       :if-exists :append)
+    (fresh-line out)
+    (apply #'format out fmt args)
+    (terpri out)))
+
+(defun change-current-connection (conn)
+  (when *connection*
+    (abort-all *connection* "change connection")
+    (notify-change-connection-to-wait-message-thread))
+  (setf *connection* conn))
+
+(defun connected-p ()
+  (not (null *connection*)))
+
+(defun add-connection (conn)
+  (push conn *connection-list*)
+  (change-current-connection conn))
+
+(defun remove-connection (conn)
+  (setf *connection-list* (delete conn *connection-list*))
+  ;(change-current-connection (car *connection-list*))
+  (setf *connection* (car *connection-list*))
+  *connection*)
+
+(define-command scheme-connection-list () ()
+  (lem.menu-mode:display-menu
+   (make-instance 'lem.menu-mode:menu
+                  :columns '(" " "hostname" "port" "pid" "name" "version" "command")
+                  :items *connection-list*
+                  :column-function (lambda (c)
+                                     (list (if (eq c *connection*) "*" "")
+                                           (connection-hostname c)
+                                           (connection-port c)
+                                           (connection-pid c)
+                                           (connection-implementation-name c)
+                                           (connection-implementation-version c)
+                                           (connection-command c)))
+                  :select-callback (lambda (menu c)
+                                     (change-current-connection c)
+                                     (lem.menu-mode:update-menu menu *connection-list*)
+                                     :close)
+                  :update-items-function (lambda () *connection-list*))
+   :name "Scheme Connections"))
+
+(defun check-connection ()
+  (unless (connected-p)
+    (editor-error "No connection for repl.")))
+
+;; for r7rs-swank (check unsupported function)
+(defun check-aborted (message)
+  (alexandria:destructuring-case message
+    ((:return value id)
+     (declare (ignore id))
+     (alexandria:destructuring-case value
+       ((:abort string)
+        (declare (ignore string))
+        t)))))
+
+(defun buffer-package (buffer &optional default)
+  (let ((package-name (buffer-value buffer "package" default)))
+    (typecase package-name
+      (null default)
+      ((or symbol string)
+       ;(string-upcase package-name)
+       package-name
+       )
+      ((cons (or symbol string))
+       ;(string-upcase (car package-name))
+       (car package-name)
+       ))))
+
+(defun (setf buffer-package) (package buffer)
+  (setf (buffer-value buffer "package") package))
+
+(defvar *current-package* nil)
+
+(defun current-package ()
+  (or *current-package*
+      (buffer-package (current-buffer))
+      (connection-package *connection*)))
+
+(defun current-swank-thread ()
+  (or (buffer-value (current-buffer) 'thread)
+      t))
+
+(defun features ()
+  (when (connected-p)
+    (connection-features *connection*)))
+
+(defun indentation-update (info)
+  (declare (ignore info))
+  ;(push (list :indentation-update info) lem-lisp-syntax.indent::*indent-log*)
+  ;(loop :for (name indent packages) :in info
+  ;      :do (lem-lisp-syntax:update-system-indentation name indent packages))
+  ;#+(or)
+  ;(loop :for (name indent packages) :in info
+  ;      :do (dolist (package packages)
+  ;            (unless (gethash package *indent-table*)
+  ;              (setf (gethash package *indent-table*)
+  ;                    (make-hash-table :test 'equal)))
+  ;            (setf (gethash name (gethash package *indent-table*)) indent)))
+  )
+
+(defun scheme-rex (form &key
+                        continuation
+                        (thread (current-swank-thread))
+                        (package (current-package)))
+  (emacs-rex *connection*
+             form
+             :continuation continuation
+             :thread thread
+             :package package))
+
+(defun scheme-eval-internal (emacs-rex-fun rex-arg package)
+  (let ((tag (gensym))
+        (thread-id (current-swank-thread)))
+    (catch tag
+      (funcall emacs-rex-fun
+               *connection*
+               rex-arg
+               :continuation (lambda (result)
+                               (alexandria:destructuring-ecase result
+                                 ((:ok value)
+                                  (throw tag value))
+                                 ((:abort condition)
+                                  (declare (ignore condition))
+                                  (editor-error "Synchronous Scheme Evaluation aborted"))))
+               :package package
+               :thread thread-id)
+      (handler-case (loop (sit-for 10 nil))
+        (editor-abort ()
+          (send-message-string *connection* (format nil "(:emacs-interrupt ~D)" thread-id))
+          (keyboard-quit))))))
+
+(defun scheme-eval-from-string (string &optional (package (current-package)))
+  (scheme-eval-internal 'emacs-rex-string string package))
+
+(defun scheme-eval (sexp &optional (package (current-package)))
+  (scheme-eval-internal 'emacs-rex sexp package))
+
+(defun scheme-eval-async (form &optional cont (package (current-package)))
+  (let ((buffer (current-buffer)))
+    (scheme-rex form
+                :continuation (lambda (value)
+                                (alexandria:destructuring-ecase value
+                                  ((:ok result)
+                                   (when cont
+                                     (let ((prev (current-buffer)))
+                                       (setf (current-buffer) buffer)
+                                       (funcall cont result)
+                                       (unless (eq (current-buffer)
+                                                   (window-buffer (current-window)))
+                                         (setf (current-buffer) prev)))))
+                                  ((:abort condition)
+                                   (unless *suppress-error-disp*
+                                     (message "Evaluation aborted on ~A." condition))))
+                                (setf *suppress-error-disp* nil))
+                :thread (current-swank-thread)
+                :package package)))
+
+(defun eval-with-transcript (form)
+  (scheme-rex form
+              :continuation (lambda (value)
+                              (alexandria:destructuring-ecase value
+                                ((:ok x)
+                                 (message "~A" x))
+                                ((:abort condition)
+                                 (message "Evaluation aborted on ~A." condition))))
+              :package (current-package)))
+
+(defun re-eval-defvar (string)
+  (eval-with-transcript `(swank:re-evaluate-defvar ,string)))
+
+(defun interactive-eval (string)
+  (eval-with-transcript `(swank:interactive-eval ,string)))
+
+(defun eval-print (string &optional print-right-margin)
+  (let ((value (scheme-eval (if print-right-margin
+                                `(let ((*print-right-margin* ,print-right-margin))
+                                   (swank:eval-and-grab-output ,string))
+                                `(swank:eval-and-grab-output ,string)))))
+    (insert-string (current-point) (first value))
+    (insert-character (current-point) #\newline)
+    (insert-string (current-point) (second value))))
+
+(defun new-package (name prompt-string)
+  (setf (connection-package *connection*) name)
+  (setf (connection-prompt-string *connection*) prompt-string)
+  t)
+
+(defun read-package-name ()
+  (check-connection)
+  (let ((package-names (mapcar #'string-downcase
+                               (scheme-eval
+                                '(swank:list-all-package-names t)))))
+    ;(dbg-log-format "package-names=~S" package-names)
+    ;(string-upcase (prompt-for-line
+    (prompt-for-line ;"Package: " ""
+                     "Library: " ""
+                     (lambda (str)
+                       (completion str package-names))
+                     (lambda (str)
+                       (find str package-names :test #'string=))
+                     'mh-scheme-package)))
+
+;(define-command scheme-set-package (package-name) ((list (read-package-name)))
+(define-command scheme-set-library (package-name) ((list (read-package-name)))
+  (check-connection)
+  (cond ((string= package-name ""))
+        ((eq (current-buffer) (repl-buffer))
+         (destructuring-bind (name prompt-string)
+             (scheme-eval `(swank:set-package ,package-name))
+           (new-package name prompt-string)
+           (lem.listener-mode:listener-reset-prompt (repl-buffer))))
+        (t
+         (setf (buffer-value (current-buffer) "package") package-name))))
+
+(define-command scheme-interrupt () ()
+  (check-connection)
+  (send-message-string
+   *connection*
+   (format nil "(:emacs-interrupt ~A)" (current-swank-thread))))
+
+(defun prompt-for-sexp (string &optional initial)
+  (prompt-for-line string
+                   initial
+                   (lambda (str)
+                     (declare (ignore str))
+                     (completion-symbol (current-point)))
+                   nil
+                   'mh-scheme-sexp))
+
+(define-command scheme-eval-string (string)
+    ((list (prompt-for-sexp "Scheme Eval: ")))
+  (check-connection)
+  (interactive-eval string))
+
+(define-command scheme-eval-define () ()
+  (check-connection)
+  (with-point ((point (current-point)))
+    (lem-scheme-syntax:top-of-defun point)
+    (with-point ((start point)
+                 (end point))
+      (scan-lists end 1 0)
+      (run-hooks (variable-value 'before-eval-functions) start end)
+      (let ((string (points-to-string start end)))
+        ;(if (ppcre:scan "^\\(defvar(?:\\s|$)" string)
+        ;    (re-eval-defvar string)
+        ;    (interactive-eval string))
+        (interactive-eval string)
+        ))))
+
+(defun get-operator-name ()
+  (with-point ((point (current-point)))
+    (scan-lists point -1 1)
+    (character-offset point 1)
+    (symbol-string-at-point point)))
+
+(define-command scheme-echo-arglist () ()
+  (check-connection)
+  (let ((name (get-operator-name))
+        (package (current-package)))
+    (when name
+      (scheme-eval-async `(swank:operator-arglist ,name ,package)
+                         (lambda (arglist)
+                           (when arglist
+                             (message "~A" (ppcre:regex-replace-all "\\s+" arglist " "))))))))
+
+(let (autodoc-symbol)
+  (defun autodoc (function)
+    (let ((context (lem-scheme-syntax:parse-for-swank-autodoc (current-point))))
+      (unless autodoc-symbol
+        (setf autodoc-symbol (intern "AUTODOC" :swank))
+
+        ;; for r7rs-swank (only single colon name 'swank:autodoc' is accepted)
+        (in-package :swank)
+        (export 'swank::autodoc)
+        (in-package :lem-scheme-mode))
+
+      (setf *suppress-error-disp* t)
+      (scheme-eval-async
+       `(,autodoc-symbol ',context)
+       (lambda (doc)
+         (ignore-errors
+          (destructuring-bind (doc cache-p) doc
+            (declare (ignore cache-p))
+            (unless (eq doc :not-available)
+              (let* ((buffer (make-buffer "*swank:autodoc-fontity*"
+                                          :temporary t :enable-undo-p nil))
+                     (point (buffer-point buffer)))
+                (erase-buffer buffer)
+                (change-buffer-mode buffer 'scheme-mode)
+                (insert-string point (ppcre:regex-replace-all "\\s*\\n\\s*" doc " "))
+                (buffer-start point)
+                (multiple-value-bind (result string)
+                    (search-forward-regexp point "(?====> (.*) <===)")
+                  (when result
+                    (with-point ((start point))
+                      (character-offset point 5)
+                      (search-forward point "<===")
+                      (delete-between-points start point)
+                      (insert-string point string :attribute 'region))))
+                (funcall function buffer))))))))))
+
+(define-command scheme-autodoc-with-typeout () ()
+  (check-connection)
+  (autodoc (lambda (temp-buffer)
+             (let ((buffer (make-buffer (buffer-name temp-buffer))))
+               (erase-buffer buffer)
+               (insert-buffer (buffer-point buffer) temp-buffer)
+               (with-pop-up-typeout-window (stream buffer)
+                 (declare (ignore stream)))))))
+
+(define-command scheme-autodoc () ()
+  (check-connection)
+  (autodoc (lambda (buffer) (message-buffer buffer))))
+
+(defun check-parens ()
+  (with-point ((point (current-point)))
+    (buffer-start point)
+    (loop :while (form-offset point 1))
+    (skip-space-and-comment-forward point)
+    (end-buffer-p point)))
+
+(defun compilation-finished (result)
+
+  ;; for r7rs-swank (check unsupported function)
+  (when (check-aborted result)
+    (editor-error "Not supported."))
+
+  (setf *last-compilation-result* result)
+  (destructuring-bind (notes successp duration loadp fastfile)
+      (rest result)
+    (show-compile-result notes duration
+                         (if (not loadp)
+                             successp
+                             (and fastfile successp)))
+    (highlight-notes notes)
+    (when (and loadp fastfile successp)
+      (scheme-eval-async `(swank:load-file ,fastfile)))))
+
+(defun show-compile-result (notes secs successp)
+  (message (format nil "~{~A~^ ~}"
+                   (remove-if #'null
+                              (list (if successp
+                                        "Compilation finished"
+                                        "Compilation failed")
+                                    (unless notes
+                                      "(No warnings)")
+                                    (when secs
+                                      (format nil "[~,2f secs]" secs)))))))
+
+(defun make-highlight-overlay (pos buffer)
+  (with-point ((point (buffer-point buffer)))
+    (move-to-position point pos)
+    (skip-chars-backward point #'syntax-symbol-char-p)
+    (make-overlay point
+                  (or (form-offset (copy-point point :temporary) 1)
+                      (buffer-end-point buffer))
+                  'compiler-note-attribute)))
+
+(defvar *note-overlays* nil)
+
+(defun highlight-notes (notes)
+  (scheme-remove-notes)
+  (when (and (null notes)
+             (null (get-buffer-windows (get-buffer "*scheme-compilations*"))))
+    (return-from highlight-notes))
+  (when (dolist (note notes nil)
+          (optima:match note
+            ((optima:property :location location)
+             (when (source-location-to-xref-location location nil t)
+               (return t)))))
+    (lem.sourcelist:with-sourcelist (sourcelist "*scheme-compilations*")
+      (dolist (note notes)
+        (optima:match note
+          ((and (optima:property :location location)
+                (or (optima:property :message message) (and))
+                (or (optima:property :source-context source-context) (and)))
+           (alexandria:when-let ((xref-location (source-location-to-xref-location location nil t)))
+             (let* ((name (xref-filespec-to-filename (xref-location-filespec xref-location)))
+                    (pos (xref-location-position xref-location))
+                    (buffer (xref-filespec-to-buffer (xref-location-filespec xref-location))))
+               (lem.sourcelist:append-sourcelist
+                sourcelist
+                (lambda (cur-point)
+                  (insert-string cur-point name :attribute 'lem.sourcelist:title-attribute)
+                  (insert-string cur-point ":")
+                  (insert-string cur-point (princ-to-string pos)
+                                 :attribute 'lem.sourcelist:position-attribute)
+                  (insert-string cur-point ":")
+                  (insert-character cur-point #\newline 1)
+                  (insert-string cur-point message)
+                  (insert-character cur-point #\newline)
+                  (insert-string cur-point source-context))
+                (alexandria:curry #'go-to-location xref-location))
+               (push (make-highlight-overlay pos buffer)
+                     *note-overlays*)))))))))
+
+(define-command scheme-remove-notes () ()
+  (mapc #'delete-overlay *note-overlays*)
+  (setf *note-overlays* '()))
+
+(define-command scheme-compile-and-load-file () ()
+  (check-connection)
+
+  (unless (buffer-filename (current-buffer))
+    (editor-error "No file to compile."))
+
+  (when (buffer-modified-p (current-buffer))
+    (when (prompt-for-y-or-n-p "Save file")
+      (save-buffer)))
+  (let ((file (buffer-filename (current-buffer))))
+    (run-hooks (variable-value 'load-file-functions) file)
+    (scheme-eval-async `(swank:compile-file-for-emacs ,(write-string file) t)
+                       #'compilation-finished)))
+
+(define-command scheme-compile-region (start end) ("r")
+  (check-connection)
+  (let ((string (points-to-string start end))
+        (position `((:position ,(position-at-point start))
+                    (:line
+                     ,(line-number-at-point (current-point))
+                     ,(point-charpos (current-point))))))
+    (run-hooks (variable-value 'before-compile-functions) start end)
+    (scheme-eval-async `(swank:compile-string-for-emacs ,string
+                                                        ,(buffer-name (current-buffer))
+                                                        ',position
+                                                        ,(buffer-filename (current-buffer))
+                                                        nil)
+                     #'compilation-finished)))
+
+(define-command scheme-compile-define () ()
+  (check-connection)
+  (with-point ((point (current-point)))
+    (lem-scheme-syntax:top-of-defun point)
+    (with-point ((start point)
+                 (end point))
+      (scan-lists end 1 0)
+      (scheme-compile-region start end))))
+
+(defun form-string-at-point ()
+  (with-point ((point (current-point)))
+    (skip-chars-backward point #'syntax-symbol-char-p)
+    (with-point ((start point)
+                 (end point))
+      (form-offset end 1)
+      (points-to-string start end))))
+
+(defun macroexpand-internal (expander)
+  (let* ((self (eq (current-buffer) (get-buffer "*scheme-macroexpand*")))
+         (orig-package-name (buffer-package (current-buffer) "user"))
+         (p (and self (copy-point (current-point) :temporary))))
+    (scheme-eval-async `(,expander ,(form-string-at-point))
+                       (lambda (string)
+                         (let ((buffer (make-buffer "*scheme-macroexpand*")))
+                           (with-buffer-read-only buffer nil
+                             (unless self (erase-buffer buffer))
+                             (change-buffer-mode buffer 'scheme-mode)
+                             (setf (buffer-package buffer) orig-package-name)
+                             (when self
+                               (move-point (current-point) p)
+                               (kill-sexp))
+                             (insert-string (buffer-point buffer)
+                                            string)
+                             (indent-region (buffer-start-point buffer)
+                                            (buffer-end-point buffer))
+                             (with-pop-up-typeout-window (s buffer)
+                               (declare (ignore s)))
+                             (when self
+                               (move-point (buffer-point buffer) p))))))))
+
+(define-command scheme-macroexpand () ()
+  (check-connection)
+  ;; for r7rs-swank (swank-macroexpand-1 is not supported)
+  ;(macroexpand-internal 'swank:swank-macroexpand-1)
+  (macroexpand-internal 'swank:swank-expand-1)
+  )
+
+(define-command scheme-macroexpand-all () ()
+  (check-connection)
+  (macroexpand-internal 'swank:swank-macroexpand-all))
+
+;; for r7rs-swank (fuzzy-completions is not supported) 
+;(defvar *completion-symbol-with-fuzzy* t)
+(defvar *completion-symbol-with-fuzzy* nil)
+
+(defun symbol-completion (str &optional (package (current-package)))
+  (let* ((fuzzy *completion-symbol-with-fuzzy*)
+         (result (scheme-eval-from-string
+                  (format nil "(~A ~S ~S)"
+                          (if fuzzy
+                              "swank:fuzzy-completions"
+                              "swank:completions")
+                          str
+                          package)
+                  ;"COMMON-LISP"
+                  )))
+    (when result
+      (destructuring-bind (completions timeout-p) result
+        (declare (ignore timeout-p))
+        (completion-hypheen str (mapcar (if fuzzy #'first #'identity) completions))))))
+
+(defun prompt-for-symbol-name (prompt &optional (initial ""))
+  (let ((package (current-package)))
+    (prompt-for-line prompt
+                     initial
+                     (lambda (str)
+                       (symbol-completion str package))
+                     nil
+                     'mh-scheme-read-symbol)))
+
+(defun definition-to-location (definition)
+  (destructuring-bind (title location) definition
+    (source-location-to-xref-location location title t)))
+
+(defun definitions-to-locations (definitions)
+  (loop :for def :in definitions
+        :for xref := (definition-to-location def)
+        :when xref
+        :collect xref))
+
+;(defun find-local-definition (point name)
+;  (let ((point (lem-lisp-syntax:search-local-definition point name)))
+;    (when point
+;      (list (make-xref-location :filespec (point-buffer point)
+;                                :position (position-at-point point))))))
+
+(defun find-definitions-default (point)
+  (let ((name (or (symbol-string-at-point point)
+                  (prompt-for-symbol-name "Edit Definition of: "))))
+    ;(let ((result (find-local-definition point name)))
+    ;  (when result
+    ;    (return-from find-definitions-default result)))
+    (let ((definitions (scheme-eval `(swank:find-definitions-for-emacs ,name))))
+
+      ;; for r7rs-swank (check unsupported function)
+      (when (check-aborted definitions)
+        (editor-error "Not supported."))
+
+      (definitions-to-locations definitions))))
+
+(defparameter *find-definitions* '(find-definitions-default))
+
+(defun find-definitions (point)
+  (check-connection)
+  (some (alexandria:rcurry #'funcall point) *find-definitions*))
+
+(defun find-references (point)
+  (check-connection)
+  (let* ((name (or (symbol-string-at-point point)
+                   (prompt-for-symbol-name "Edit uses of: ")))
+         (data (scheme-eval `(swank:xrefs '(:calls :macroexpands :binds
+                                            :references :sets :specializes)
+                                          ,name))))
+
+    ;; for r7rs-swank (check unsupported function)
+    (when (check-aborted data)
+      (editor-error "Not supported."))
+
+    (loop
+      :for (type . definitions) :in data
+      :for defs := (definitions-to-locations definitions)
+      :collect (make-xref-references :type type
+                                     :locations defs))))
+
+(defun completion-symbol (point)
+  ;(check-connection)
+  (with-point ((start point)
+               (end point))
+    (skip-chars-backward start #'syntax-symbol-char-p)
+    (skip-chars-forward end #'syntax-symbol-char-p)
+    (when (point< start end)
+      (cond
+        ((connected-p)
+         (let* ((fuzzy *completion-symbol-with-fuzzy*)
+                (result
+                  (scheme-eval-from-string (format nil "(~A ~S ~S)"
+                                                   (if fuzzy
+                                                       "swank:fuzzy-completions"
+                                                       "swank:completions")
+                                                   (points-to-string start end)
+                                                   (current-package)))))
+           (when result
+             (destructuring-bind (completions timeout-p) result
+               (declare (ignore timeout-p))
+               (mapcar (lambda (completion)
+                         (make-completion-item
+                          :label (if fuzzy
+                                     (first completion)
+                                     completion)
+                          :detail (if fuzzy
+                                      (fourth completion)
+                                      "")
+                          :start start
+                          :end end))
+                       completions)))))
+        (t
+         (mapcar (lambda (name)
+                   (make-completion-item :label name
+                                         :start start
+                                         :end end))
+                 (completion (points-to-string start end)
+                             *scheme-completion-names*
+                             :test #'alexandria:starts-with-subseq)))))))
+
+(defun show-description (string)
+  (let ((buffer (make-buffer "*scheme-description*")))
+    (change-buffer-mode buffer 'scheme-mode)
+    (with-pop-up-typeout-window (stream buffer :erase t)
+      (princ string stream))))
+
+(defun scheme-eval-describe (form)
+  (scheme-eval-async form #'show-description))
+
+(define-command scheme-describe-symbol () ()
+  (check-connection)
+  (let ((symbol-name
+          (prompt-for-symbol-name "Describe symbol: "
+                            (or (symbol-string-at-point (current-point)) ""))))
+    (when (string= "" symbol-name)
+      (editor-error "No symbol given"))
+    (scheme-eval-describe `(swank:describe-symbol ,symbol-name))))
+
+(defvar *wait-message-thread* nil)
+
+(defun notify-change-connection-to-wait-message-thread ()
+  (bt:interrupt-thread *wait-message-thread*
+                       (lambda () (error 'change-connection))))
+
+(defun start-thread ()
+  (unless *wait-message-thread*
+    (setf *wait-message-thread*
+          (bt:make-thread
+           (lambda () (loop
+                        :named exit
+                        :do
+                        (handler-case
+                            (loop
+
+                              ;; workaround for windows
+                              ;;  (sleep seems to be necessary to receive
+                              ;;   change-connection event immediately)
+                              #+(and sbcl win32)
+                              (sleep 0.001)
+
+                              (unless (connected-p)
+                                (setf *wait-message-thread* nil)
+                                (return-from exit))
+                              (when (message-waiting-p *connection* :timeout 1)
+                                (let ((barrior t))
+                                  (send-event (lambda ()
+                                                (unwind-protect (progn (pull-events)
+                                                                       (redraw-display))
+                                                  (setq barrior nil))))
+                                  (loop
+                                    (unless (connected-p)
+                                      (return))
+                                    (unless barrior
+                                      (return))
+                                    (sleep 0.1)))))
+                          (change-connection ()))))
+           :name "scheme-wait-message"))))
+
+(define-command scheme-slime-connect (hostname port &optional (start-repl t))
+    ((list (prompt-for-string "Hostname: " *localhost*)
+           (parse-integer (prompt-for-string "Port: " (princ-to-string *default-port*)))
+           t))
+  (enable-scheme-slime-commands)
+  (message "Connecting...")
+  (let (connection)
+    (handler-case (setf connection
+                        (if (eq hostname *localhost*)
+                            (or (ignore-errors (new-connection "127.0.0.1" port))
+                                (new-connection "localhost" port))
+                            (new-connection hostname port)))
+      (error (c)
+        (editor-error "~A" c)))
+    (message "Swank server running on ~A ~A"
+             (connection-implementation-name connection)
+             (connection-implementation-version connection))
+    (add-connection connection)
+    (when start-repl (start-scheme-repl))
+    (start-thread)
+    connection))
+
+(defvar *unknown-keywords* nil)
+(defun pull-events ()
+  (when (and (boundp '*connection*)
+             (not (null *connection*)))
+    (handler-case (loop :while (message-waiting-p *connection*)
+                        :do (dispatch-message (read-message *connection*)))
+      (disconnected ()
+        (remove-connection *connection*)))))
+
+(defun dispatch-message (message)
+  (log-message (prin1-to-string message))
+  (dolist (e *event-hooks*)
+    (when (funcall e message)
+      (return-from dispatch-message)))
+  (alexandria:destructuring-case message
+    ((:write-string string &rest rest)
+     (declare (ignore rest))
+     ;(dbg-log-format "write-string=~S" string)
+     (funcall *write-string-function* string))
+    ((:read-string thread tag)
+     (repl-read-string thread tag))
+    ((:read-aborted thread tag)
+     (repl-abort-read thread tag))
+    ;; ((:open-dedicated-output-stream port coding-system)
+    ;;  )
+    ((:new-package name prompt-string)
+     (new-package name prompt-string))
+    ((:return value id)
+
+     ;; for r7rs-swank (display error message)
+     (unless *suppress-error-disp*
+       (alexandria:destructuring-case value
+         ((:abort string)
+          (funcall *write-string-function* 
+                   (format nil "; Evaluation aborted: ~A~%" string)))))
+
+     (finish-evaluated *connection* value id))
+    ;; ((:channel-send id msg)
+    ;;  )
+    ;; ((:emacs-channel-send id msg)
+    ;;  )
+    ((:read-from-minibuffer thread tag prompt initial-value)
+     (read-from-minibuffer thread tag prompt initial-value))
+    ((:y-or-n-p thread tag question)
+     (dispatch-message `(:emacs-return ,thread ,tag ,(prompt-for-y-or-n-p question))))
+    ((:emacs-return-string thread tag string)
+     (send-message-string
+      *connection*
+      (format nil "(:emacs-return-string ~A ~A ~S)"
+              thread
+              tag
+              string)))
+    ((:new-features features)
+     (setf (connection-features *connection*)
+           features))
+    ((:indentation-update info)
+     (indentation-update info))
+    ((:eval-no-wait form)
+     (eval (read-from-string form)))
+    ;; ((:eval thread tag form-string)
+    ;;  )
+    ((:emacs-return thread tag value)
+     (send-message-string
+      *connection*
+      (format nil "(:emacs-return ~A ~A ~S)" thread tag value)))
+    ;; ((:ed what)
+    ;;  )
+    ;; ((:inspect what thread tag)
+    ;;  )
+    ;; ((:background-message message)
+    ;;  )
+    ((:debug-condition thread message)
+     (assert thread)
+     (message "~A" message))
+    ((:ping thread tag)
+     (send-message-string
+      *connection*
+      (format nil "(:emacs-pong ~A ~A)" thread tag)))
+    ;; ((:reader-error packet condition)
+    ;;  )
+    ;; ((:invalid-rpc id message)
+    ;;  )
+    ;; ((:emacs-skipped-packet _pkg))
+    ;; ((:test-delay seconds)
+    ;;  )
+    ((t &rest args)
+     (declare (ignore args))
+     (pushnew (car message) *unknown-keywords*))))
+
+(defun read-from-minibuffer (thread tag prompt initial-value)
+  (let ((input (prompt-for-sexp prompt initial-value)))
+    (dispatch-message `(:emacs-return ,thread ,tag ,input))))
+
+(defun show-source-location (source-location)
+  (alexandria:destructuring-case source-location
+    ((:error message)
+     (message "~A" message))
+    ((t &rest _)
+     (declare (ignore _))
+     (let ((xref-location (source-location-to-xref-location source-location)))
+       (go-to-location xref-location
+                       (lambda (buffer)
+                         (setf (current-window)
+                               (pop-to-buffer buffer))))))))
+
+(defun source-location-to-xref-location (location &optional content no-errors)
+  (alexandria:destructuring-ecase location
+    ((:location location-buffer position _hints)
+     (declare (ignore _hints))
+     (let ((buffer (location-buffer-to-buffer location-buffer)))
+       (with-point ((point (buffer-point buffer)))
+         (move-to-location-position point position)
+         (make-xref-location :content (or content "")
+                             :filespec buffer
+                             :position (position-at-point point)))))
+    ((:error message)
+     (unless no-errors
+       (editor-error "~A" message)))))
+
+(defun location-buffer-to-buffer (location-buffer)
+  (alexandria:destructuring-ecase location-buffer
+    ((:file filename)
+     (find-file-buffer filename))
+    ((:buffer buffer-name)
+     (let ((buffer (get-buffer buffer-name)))
+       (unless buffer (editor-error "~A is already deleted buffer" buffer-name))
+       buffer))
+    ((:buffer-and-file buffer filename)
+     (or (get-buffer buffer)
+         (find-file-buffer filename)))
+    ((:source-form string)
+     (let ((buffer (make-buffer "*scheme-source*")))
+       (erase-buffer buffer)
+       (change-buffer-mode buffer 'scheme-mode)
+       (insert-string (buffer-point buffer) string)
+       (buffer-start (buffer-point buffer))
+       buffer))
+    #+(or)((:zip file entry))
+    ))
+
+(defun move-to-bytes (point bytes)
+  (buffer-start point)
+  (loop
+    (let ((size (1+ (babel:string-size-in-octets (line-string point)))))
+      (when (<= bytes size)
+        (loop :for i :from 0
+              :do
+                 (decf bytes (babel:string-size-in-octets (string (character-at point i))))
+                 (when (<= bytes 0)
+                   (character-offset point i)
+                   (return-from move-to-bytes point))))
+      (decf bytes size)
+      (unless (line-offset point 1) (return)))))
+
+(defun move-to-location-position (point location-position)
+  (alexandria:destructuring-ecase location-position
+    ((:position pos)
+     (move-to-bytes point (1+ pos)))
+    ((:offset start offset)
+     (move-to-position point (1+ start))
+     (character-offset point offset))
+    ((:line line-number &optional column)
+     (move-to-line point line-number)
+     (if column
+         (line-offset point 0 column)
+         (back-to-indentation point)))
+    ((:function-name name)
+     (buffer-start point)
+     (search-forward-regexp point (ppcre:create-scanner
+                                   `(:sequence
+                                     "(def"
+                                     (:greedy-repetition 1 nil (:char-class :word-char-class #\-))
+                                     (:greedy-repetition 1 nil :whitespace-char-class)
+                                     (:greedy-repetition 0 nil #\()
+                                     ,name
+                                     (:char-class :whitespace-char-class #\( #\)))
+                                   :case-insensitive-mode t))
+     (line-start point))
+    ;; ((:method name specializers &rest qualifiers)
+    ;;  )
+    ;; ((:source-path source-path start-position)
+    ;;  )
+    ((:eof)
+     (buffer-end point))))
+
+(defun initialize-forms-string (port)
+  (with-output-to-string (out)
+    (format out "(swank:create-server :port ~D :dont-close t)~%" port)
+    (write-line "(loop (sleep most-positive-fixnum))" out)))
+
+(defun run-swank-server (command port &key (directory (buffer-directory)))
+  (bt:make-thread
+   (lambda ()
+     (with-input-from-string
+         (input (initialize-forms-string port))
+       (multiple-value-bind (output error-output status)
+
+           ;; for r7rs-swank (error check)
+           (handler-case
+               (uiop:run-program command
+                                 ;:input input
+                                 :output :string
+                                 :error-output :string
+                                 :directory directory
+                                 :ignore-error-status t)
+             (error (c) (values "" (format nil "~A" c) -1)))
+
+         (unless (zerop status)
+           (send-event (lambda ()
+                         (let ((buffer (make-buffer "*Run Scheme Output*")))
+                           (with-pop-up-typeout-window (stream buffer
+                                                               :focus t
+                                                               :erase t
+                                                               :read-only t)
+                             (format stream "command: ~A~%" command)
+                             (format stream "status: ~A~%" status)
+                             (format stream "port: ~A~%" port)
+                             (format stream "directory: ~A~%" directory)
+                             (write-string output stream)
+                             (write-string error-output stream)))))))))
+   :name (format nil "run-scheme-swank-server-thread '~A'" command)))
+
+(defun run-slime (command &key (directory (buffer-directory)))
+  ;(unless command
+  ;  (setf command (get-lisp-command :impl *impl-name*)))
+  (let ((port (or (port-available-p *default-port*)
+                  (random-port))))
+
+    ;; for r7rs-swank (make command)
+    (unless command
+      (setf command
+            (mapcar (lambda (str)
+                      (ppcre:regex-replace-all ",port"
+                                               str
+                                               (write-to-string port)))
+                    (uiop:ensure-list *scheme-swank-server-run-command*))))
+    ;(dbg-log-format "command=~S" command)
+
+    (run-swank-server command port :directory directory)
+    (sleep 0.5)
+    (let ((successp)
+          (condition))
+      (loop :repeat 10
+            :do (handler-case
+                    (let ((conn (scheme-slime-connect *localhost* port t)))
+                      (setf (connection-command conn) command)
+                      (setf (connection-process-directory conn) directory)
+                      (setf successp t)
+                      (return))
+                  (editor-error (c)
+                    (setf condition c)
+                    (sleep 0.5))))
+      (unless successp
+        (error condition)))
+    #-win32
+    (add-hook *exit-editor-hook* 'slime-quit-all)))
+
+;(define-command scheme-slime (&optional ask-impl) ("P")
+;  (let ((command (if ask-impl (prompt-for-impl))))
+;    (run-slime command)))
+(define-command scheme-slime () ()
+  (enable-scheme-slime-commands)
+  (run-slime nil))
+
+(define-command scheme-slime-quit () ()
+  (when *connection*
+    (prog1 (when (connection-command *connection*)
+             ;(scheme-rex '(uiop:quit))
+             ;(scheme-rex '(swank:quit-lisp))
+             (interactive-eval "(exit)")
+             t)
+      (remove-connection *connection*))))
+
+(defun slime-quit* ()
+  (ignore-errors (scheme-slime-quit)))
+
+(defun slime-quit-all ()
+  (flet ((find-connection ()
+           (dolist (c *connection-list*)
+             (when (connection-command c)
+               (return c)))))
+    (loop
+      (let ((*connection* (find-connection)))
+        (unless *connection* (return))
+        ;(ignore-errors (scheme-rex '(uiop:quit)))
+        ;(ignore-errors (scheme-rex '(swank:quit-lisp)))
+        (ignore-errors (interactive-eval "(exit)"))
+        (remove-connection *connection*)))))
+
+(defun sit-for* (second)
+  (loop :with end-time := (+ (get-internal-real-time)
+                             (* second internal-time-units-per-second))
+        :for e := (read-event (float
+                               (/ (- end-time (get-internal-real-time))
+                                  internal-time-units-per-second)))
+        :while (key-p e)))
+
+(define-command scheme-slime-restart () ()
+  (when *connection*
+    (alexandria:when-let ((last-command (connection-command *connection*))
+                          (directory (connection-process-directory *connection*)))
+      (when (scheme-slime-quit)
+        (sit-for* 3)
+        (run-slime last-command :directory directory)))))
+
+(defun scan-current-package (point)
+  (with-point ((p point))
+    (loop
+      (multiple-value-bind (result groups)
+          (looking-at (line-start p)
+          ;            "^\\s*\\((?:cl:)?in-package (?:#?:|')?([^\)]*)\\)")
+                      "^\\s*\\(select-module\\s*([^\)]*)\\)")
+        (when result
+          (let ((package (aref groups 0)))
+            (when package
+              (return package))))
+        (unless (line-offset p -1)
+          (return))))))
+
+(defun update-buffer-package ()
+  (let ((package (scan-current-package (current-point))))
+    (when package
+      (scheme-set-library package))))
+
+(defun scheme-idle-function ()
+  (when (connected-p)
+    (let ((major-mode (buffer-major-mode (current-buffer))))
+      (when (eq major-mode 'scheme-mode) (update-buffer-package))
+      (when (member major-mode '(scheme-mode scheme-repl-mode))
+        (unless (active-echoarea-p)
+          (scheme-autodoc))))))
+
+(defun highlight-region (start end attribute name)
+  (let ((overlay (make-overlay start end attribute)))
+    (start-timer 100
+                 nil
+                 (lambda ()
+                   (delete-overlay overlay))
+                 (lambda (err)
+                   (declare (ignore err))
+                   (ignore-errors
+                    (delete-overlay overlay)))
+                 name)))
+
+(defun highlight-compilation-region (start end)
+  (highlight-region start
+                    end
+                    'compilation-region-highlight
+                    "delete-compilation-region-overlay"))
+
+(defun highlight-evaluation-region (start end)
+  (highlight-region start
+                    end
+                    'evaluation-region-highlight
+                    "delete-evaluation-region-overlay"))
+
+(add-hook (variable-value 'before-compile-functions :global)
+          'highlight-compilation-region)
+
+(add-hook (variable-value 'before-eval-functions :global)
+          'highlight-evaluation-region)
+
+;; workaround for windows
+#+win32
+(progn
+  (defun slime-quit-all-for-win32 ()
+    "quit slime and remove connection to exit lem normally on windows (incomplete)"
+    (let ((conn-list (copy-list *connection-list*)))
+      (slime-quit-all)
+      (loop :while *connection*
+            :do (remove-connection *connection*))
+      #+sbcl
+      (progn
+        (sleep 0.5)
+        (dolist (c conn-list)
+          (let* ((s  (lem-scheme-mode.swank-protocol::connection-socket c))
+                 (fd (sb-bsd-sockets::socket-file-descriptor (usocket:socket s))))
+            (ignore-errors
+              ;;(usocket:socket-shutdown s :IO)
+              ;;(usocket:socket-close s)
+              (sockint::shutdown fd sockint::SHUT_RDWR)
+              (sockint::close fd)))))))
+  (add-hook *exit-editor-hook* 'slime-quit-all-for-win32))
+

--- a/modes/scheme-mode/swank-protocol.lisp
+++ b/modes/scheme-mode/swank-protocol.lisp
@@ -1,0 +1,435 @@
+(defpackage lem-scheme-mode.swank-protocol
+  (:use :cl :lem-scheme-mode.errors)
+  (:import-from :trivial-types
+                :association-list
+                :proper-list)
+  (:export :connection
+           :connection-hostname
+           :connection-port
+           :connection-request-count
+           :connection-package
+           :connection-prompt-string
+           :connection-features
+           :connection-command
+           :connection-process-directory
+           :connection-plist)
+  (:export :new-connection
+           :log-message
+           :read-message-string
+           :send-message-string
+           :send-message
+           :message-waiting-p
+           :emacs-rex-string
+           :emacs-rex
+           :finish-evaluated
+           :abort-all
+           :request-connection-info
+           :request-swank-require
+           :request-listener-eval
+           :read-message
+           :read-all-messages)
+  (:export :connection-package
+           :connection-pid
+           :connection-implementation-name
+           :connection-implementation-version
+           :connection-machine-type
+           :connection-machine-version
+           :connection-swank-version)
+  (:documentation "Low-level implementation of a client for the Swank protocol."))
+(in-package :lem-scheme-mode.swank-protocol)
+
+;; debug log
+(defun dbg-log-format (fmt &rest args)
+  (with-open-file (out "lemlog_swankproto0001.txt"
+                       :direction :output
+                       :if-does-not-exist :create
+                       :if-exists :append)
+    (fresh-line out)
+    (apply #'format out fmt args)
+    (terpri out)))
+
+(defmacro with-swank-syntax (() &body body)
+  `(with-standard-io-syntax
+     (let ((*package* (find-package :swank-io-package))
+           (*print-case* :downcase)
+           ;; for r7rs-swank
+           ;;  (string literal '#a((32) common-lisp:base-char . "filepath")'
+           ;;   is not accepted)
+           (*print-readably* nil))
+       ,@body)))
+
+;;; Encoding and decoding messages
+
+(defun encode-integer (integer)
+  "Encode an integer to a 0-padded 16-bit hexadecimal string."
+  (babel:string-to-octets (format nil "~6,'0,X" integer)))
+
+(defun decode-integer (string)
+  "Decode a string representing a 0-padded 16-bit hex string to an integer."
+  (parse-integer string :radix 16))
+
+;; Writing and reading messages to/from streams
+
+(defun write-message-to-stream (stream message)
+  "Write a string to a stream, prefixing it with length information for Swank."
+  (let* ((octets (babel:string-to-octets message))
+         (length-octets (encode-integer (length octets)))
+         (msg (make-array (+ (length length-octets)
+                             (length octets))
+                          :element-type '(unsigned-byte 8))))
+    (replace msg length-octets)
+    (replace msg octets :start1 (length length-octets))
+    (write-sequence msg stream)))
+
+(defun read-message-from-stream (stream)
+  "Read a string from a string.
+
+Parses length information to determine how many characters to read."
+  (let ((length-buffer (make-array 6 :element-type '(unsigned-byte 8))))
+    (when (/= 6 (read-sequence length-buffer stream))
+      (error 'disconnected))
+    (let* ((length (decode-integer (babel:octets-to-string length-buffer)))
+           (buffer (make-array length :element-type '(unsigned-byte 8))))
+      (read-sequence buffer stream)
+      (babel:octets-to-string buffer))))
+
+;;; Data
+
+(defclass connection ()
+  ((hostname
+    :reader connection-hostname
+    :initarg :hostname
+    :type string
+    :documentation "The host to connect to.")
+   (port
+    :reader connection-port
+    :initarg :port
+    :type integer
+    :documentation "The port to connect to.")
+   (socket
+    :reader connection-socket
+    :initarg :socket
+    :type usocket:stream-usocket
+    :documentation "The usocket socket.")
+   (request-count
+    :accessor connection-request-count
+    :initform 0
+    :type integer
+    :documentation "A number that is increased and sent along with every request.")
+   (package
+    :accessor connection-package
+    :initform "user"
+    :type string
+    :documentation "The name of the connection's package.")
+   (prompt-string
+    :accessor connection-prompt-string
+    :type string)
+   (continuations
+    :accessor connection-continuations
+    :initform nil)
+   (debug-level :accessor connection-debug-level
+                :initform 0
+                :type integer
+                :documentation "The depth at which the debugger is called.")
+   (pid :accessor connection-pid
+        :type integer
+        :documentation "The PID of the Swank server process.")
+   (implementation-name :accessor connection-implementation-name
+                        :type string
+                        :documentation "The name of the implementation running
+ the Swank server.")
+   (implementation-version :accessor connection-implementation-version
+                           :type string
+                           :documentation "The version string of the
+ implementation running the Swank server.")
+   (machine-type :accessor connection-machine-type
+                 :type string
+                 :documentation "The server machine's architecture.")
+   (machine-version :accessor connection-machine-version
+                    :type string
+                    :documentation "The server machine's processor type.")
+   (swank-version :accessor connection-swank-version
+                  :type string
+                  :documentation "The server's Swank version.")
+   (features :accessor connection-features)
+   (info :accessor connection-info)
+   (command :initform nil :accessor connection-command)
+   (connection-process-directory
+    :initform nil
+    :accessor connection-process-directory)
+   (plist :initform nil :accessor connection-plist))
+  (:documentation "A connection to a remote Scheme."))
+
+(defun new-connection (hostname port)
+  (let* ((socket (usocket:socket-connect hostname port :element-type '(unsigned-byte 8)))
+         (connection (make-instance 'connection
+                                    :hostname hostname
+                                    :port port
+                                    :socket socket)))
+    (setup connection)
+    connection))
+
+(defun read-return-message (connection)
+  "Read only ':return' message. Other messages such as ':indentation-update' are dropped."
+  (loop :for info := (read-message connection)
+        :until (eq (car info) :return)
+        :finally (return info)))
+
+(defun setup (connection)
+  (emacs-rex connection `(swank:connection-info))
+  ;; Read the connection information message
+  (let* ((info (read-return-message connection))
+         (data (getf (getf info :return) :ok))
+         (impl (getf data :lisp-implementation))
+         (machine (getf data :machine)))
+    (setf (connection-info connection) info)
+    (setf (connection-pid connection)
+          (getf data :pid)
+          (connection-implementation-name connection)
+          (getf impl :name)
+          (connection-implementation-version connection)
+          (getf impl :version)
+          (connection-machine-type connection)
+          (getf machine :type)
+          (connection-machine-version connection)
+          (getf machine :version)
+          (connection-swank-version connection)
+          (getf data :version)
+          (connection-features connection)
+          (getf data :features)
+          (connection-package connection)
+          (getf (getf data :package) :name)
+          (connection-prompt-string connection)
+          (getf (getf data :package) :prompt)
+          ))
+  ;; Require some Swank modules
+  (request-swank-require
+   connection
+   '(swank-trace-dialog
+     swank-package-fu
+     swank-presentations
+     swank-fuzzy
+     swank-fancy-inspector
+     swank-c-p-c
+     swank-arglists
+     swank-repl))
+  (read-return-message connection)
+  ;; Start it up
+  (emacs-rex-string connection "(swank:init-presentations)")
+  (read-return-message connection)
+  (emacs-rex-string connection "(swank-repl:create-repl nil :coding-system \"utf-8-unix\")")
+  ;; Wait for startup
+  (read-return-message connection)
+  ;; Read all the other messages, dumping them
+  (read-all-messages connection))
+
+(defvar *event-log* '())
+
+(defun log-message (string)
+  "Log a message."
+  (push string *event-log*))
+
+(defun read-message-string (connection)
+  "Read a message string from a Swank connection.
+
+This function will block until it reads everything. Consider message-waiting-p
+to check if input is available."
+  (let* ((socket (connection-socket connection))
+         (stream (usocket:socket-stream socket)))
+    ;(when (usocket:wait-for-input socket :timeout 5)
+    ;  (let ((msg (read-message-from-stream stream)))
+    ;    msg))))
+    (read-message-from-stream stream)))
+
+(defun send-message-string (connection message)
+  "Send a message string to a Swank connection."
+  (let* ((socket (connection-socket connection))
+         (stream (usocket:socket-stream socket)))
+    (write-message-to-stream stream message)
+    (force-output stream)
+    message))
+
+(defun send-message (connection form)
+  (send-message-string connection
+                       (with-swank-syntax ()
+                         (prin1-to-string form))))
+
+;; workaround for windows
+;;  (usocket:wait-for-input needs WSAResetEvent before call)
+#+(and sbcl win32)
+(sb-alien:define-alien-routine ("WSAResetEvent" wsa-reset-event)
+    (boolean #.(sb-alien:alien-size sb-alien:int))
+  (event-object usocket::ws-event))
+
+(defun message-waiting-p (connection &key (timeout 0))
+  "t if there's a message in the connection waiting to be read, nil otherwise."
+
+  ;; check stream buffer
+  (let* ((socket (connection-socket connection))
+         (stream (usocket:socket-stream socket)))
+    (if (listen stream)
+        (return-from message-waiting-p t)))
+
+  ;; workaround for windows
+  ;;  (usocket:wait-for-input needs WSAResetEvent before call)
+  #+(and sbcl win32)
+  (let ((socket (connection-socket connection)))
+    (when (usocket::wait-list socket)
+      (wsa-reset-event
+       (usocket::os-wait-list-%wait
+        (usocket::wait-list socket)))))
+
+  ;; check socket buffer
+  (if (usocket:wait-for-input (connection-socket connection)
+                              :ready-only t
+                              :timeout timeout)
+      t
+      nil))
+
+;;; Sending messages
+
+(defun emacs-rex-string (connection string &key continuation thread package)
+  (let ((msg (format nil "(:emacs-rex ~A ~S ~A ~A)"
+                     string
+                     (or package
+                         (connection-package connection))
+                     (or thread t)
+                     (incf (connection-request-count connection)))))
+    (log-message msg)
+    (when continuation
+      (push (cons (connection-request-count connection)
+                  continuation)
+            (connection-continuations connection)))
+    (send-message-string connection msg)))
+
+(defun emacs-rex (connection form &key continuation thread package)
+  (emacs-rex-string connection
+                    (with-swank-syntax ()
+                      (prin1-to-string form))
+                    :continuation continuation
+                    :thread thread
+                    :package package))
+
+(defun finish-evaluated (connection value id)
+  (let ((elt (assoc id (connection-continuations connection))))
+    (when elt
+      (setf (connection-continuations connection)
+            (remove id (connection-continuations connection) :key #'car))
+      (funcall (cdr elt) value))))
+
+(defun abort-all (connection condition)
+  (loop :for (id . fn) :in (connection-continuations connection)
+        :do (funcall fn `(:abort ,condition)))
+  (setf (connection-continuations connection) nil))
+
+(defun request-swank-require (connection requirements)
+  "Request that the Swank server load contrib modules.
+`requirements` must be a list of symbols, e.g. '(swank-repl swank-media)."
+  (emacs-rex connection
+             `(let ((*load-verbose* nil)
+                    (*compile-verbose* nil)
+                    (*load-print* nil)
+                    (*compile-print* nil))
+                (handler-bind ((warning #'muffle-warning))
+                  (swank:swank-require ',(loop for item in requirements collecting
+                                                  (intern (symbol-name item)
+                                                          (find-package :swank-io-package))))))))
+
+(defun request-listener-eval (connection string &optional continuation window-width)
+  "Request that Swank evaluate a string of code in the REPL."
+  (emacs-rex-string connection
+                    (if window-width
+                        (format nil "(swank-repl:listener-eval ~S :window-width ~A)" string window-width)
+                        (format nil "(swank-repl:listener-eval ~S)" string))
+                    :continuation continuation
+                    :thread ":repl-thread"))
+
+;;; Reading/parsing messages
+
+(defun read-atom (in)
+  (let ((token
+         (coerce (loop :for c := (peek-char nil in nil)
+                       :until (or (null c) (member c '(#\( #\) #\space #\newline #\tab)))
+                       :collect c
+                       :do (read-char in))
+                 'string)))
+    (handler-case (read-from-string token)
+      (error ()
+        (let ((name (ppcre:scan-to-strings "::?.*" token)))
+          (intern (string-upcase (string-left-trim ":" name))
+                  :keyword))))))
+
+;; for r7rs-swank (replace backslash character sequence)
+(defun read-string (in)
+  (let ((token
+         (coerce (loop :for c := (peek-char nil in nil)
+                       :with c2
+                       :with clist
+                       :with dq-count := 0
+                       :until (or (null c) (>= dq-count 2))
+                       :do (read-char in)
+                           (when (char= c #\") (incf dq-count))
+                           (cond
+                             ((char= c #\\)
+                              (setf c2 (peek-char nil in nil))
+                              (unless (null c2) (read-char in))
+                              (cond
+                                ((null c2)
+                                 (push c clist))
+                                ((char= c2 #\n)
+                                 (push #\newline clist))
+                                ((char= c2 #\t)
+                                 (push #\tab clist))
+                                (t
+                                 (push c clist)
+                                 (push c2 clist))))
+                             (t
+                              (push c clist)))
+                       :finally (return (reverse clist)))
+                 'string)))
+    ;(dbg-log-format "string=~S" token)
+    (read-from-string token)))
+
+(defun read-list (in)
+  (read-char in)
+  (loop :until (eql (peek-char t in) #\))
+        :collect (read-ahead in)
+        :finally (read-char in)))
+
+(defun read-sharp (in)
+  (read-char in)
+  (case (peek-char nil in)
+    ((#\()
+     (let ((list (read-list in)))
+       (make-array (length list) :initial-contents list)))
+    ((#\\)
+     (read-char in)
+     (read-char in))
+    (otherwise
+     (unread-char #\# in))))
+
+(defun read-ahead (in)
+  (let ((c (peek-char t in)))
+    (case c
+      ((#\()
+       (read-list in))
+      ((#\")
+       ;(read in))
+       (read-string in))
+      ((#\#)
+       (read-sharp in))
+      (otherwise
+       (read-atom in)))))
+
+(defun read-from-string* (string)
+  (with-input-from-string (in string)
+    (read-ahead in)))
+
+(defun read-message (connection)
+  "Read an arbitrary message from a connection."
+  (with-swank-syntax ()
+    (read-from-string* (read-message-string connection))))
+
+(defun read-all-messages (connection)
+  (loop while (message-waiting-p connection) collecting
+    (read-message connection)))

--- a/modes/scheme-mode/syntax-parse.lisp
+++ b/modes/scheme-mode/syntax-parse.lisp
@@ -1,0 +1,65 @@
+(defpackage :lem-scheme-syntax.parse
+  (:use :cl :lem-base)
+  (:export :parse-for-swank-autodoc))
+(in-package :lem-scheme-syntax.parse)
+
+(defvar *cursor-marker* 'swank::%cursor-marker%)
+
+(defun parsing-safe-p (point)
+  (not (in-string-or-comment-p point)))
+
+(defun parse-for-swank-autodoc (point)
+  (and (parsing-safe-p point)
+       (parse-form-upto-toplevel point 10)))
+
+(defun compare-char (point offset fn &optional unescape)
+  (and (funcall fn (character-at point offset))
+       (if unescape
+           (not (syntax-escape-char-p
+                 (character-at point (1- offset))))
+           t)))
+
+(defun parse-form-upto-toplevel (point &optional limit-levels)
+  (with-point ((point point))
+    (let ((suffix (list *cursor-marker*)))
+      (cond ((compare-char point 0 #'syntax-open-paren-char-p t)
+             (and (form-offset point 1)
+                  (push "" suffix)))
+            ((or (start-line-p point)
+                 (compare-char point -1 #'syntax-space-char-p t))
+             (push "" suffix))
+            ((compare-char point -1 #'syntax-open-paren-char-p t)
+             (push "" suffix))
+            (t
+             (skip-symbol-forward point)))
+      (with-point ((end point))
+        (loop :repeat (or limit-levels most-positive-fixnum)
+              :while (scan-lists point -1 1 t)
+              :do (when (start-line-p point) (return)))
+        (scan-lists point 1 -1 t)
+        (parse-region point end suffix)))))
+
+(defun parse-region (start end suffix)
+  (with-point ((tmp start))
+    (labels ((f (start end)
+               (let ((p start)
+                     (sexp '()))
+                 (loop
+                   (skip-space-and-comment-forward p)
+                   (when (point<= end p)
+                     (dolist (s suffix) (push s sexp))
+                     (setq suffix nil)
+                     (return-from f (nreverse sexp)))
+                   (let ((c (character-at p)))
+                     (cond ((syntax-open-paren-char-p c)
+                            (character-offset p 1)
+                            (push (f p end) sexp))
+                           ((syntax-closed-paren-char-p c)
+                            (character-offset p 1)
+                            (return))
+                           (t
+                            (move-point tmp p)
+                            (unless (form-offset p 1) (return))
+                            (push (points-to-string tmp p) sexp)))))
+                 (nreverse sexp))))
+      (f start end))))

--- a/modes/scheme-mode/util.lisp
+++ b/modes/scheme-mode/util.lisp
@@ -1,0 +1,30 @@
+(defpackage :lem-scheme-mode.util
+  (:use :cl)
+  (:import-from :lem
+                :random-range)
+  (:export :port-available-p
+           :random-port))
+(in-package :lem-scheme-mode.util)
+
+(defun port-available-p (port)
+  (let (socket)
+    (unwind-protect
+         (handler-case (progn
+                         (setq socket (usocket:socket-listen "127.0.0.1" port :reuse-address nil))
+                         port)
+           (usocket:address-in-use-error () nil)
+           (usocket:socket-error (e)
+             (warn "USOCKET:SOCKET-ERROR: ~A" e)
+             nil)
+           #+sbcl
+           (sb-bsd-sockets:socket-error (e)
+             (warn "SB-BSD-SOCKETS:SOCKET-ERROR: ~A" e)
+             nil))
+      (when socket
+        (usocket:socket-close socket)
+        port))))
+
+(defun random-port ()
+  (loop :for port := (random-range 49152 65535)
+        :when (port-available-p port)
+        :return port))


### PR DESCRIPTION
scheme-mode に scheme-slime コマンドを追加して、
[r7rs-swank] に接続できるようにしてみました。

--
＜使い方＞
[r7rs-swank] は GitHub から入手して、適当なフォルダに配置が必要です。

init.lisp に、次のように起動コマンドを記述します。
```
(setf lem-scheme-mode:*scheme-swank-server-run-command*
      '("gosh" "-AC:/work/r7rs-swank" "-e(begin (import (gauche-swank)) (start-swank ,port))"))
```
(上記は、Scheme 処理系に Gauche を使うときの例です。
`-A` オプションには r7rs-swank のフォルダのパスを指定します。
ポート番号を指定する箇所には `,port` と記述します (lem が内部で実際のポート番号に置換します))

後は、lem を起動して、M-x scheme-slime とすると、
swank-server が起動して、repl のバッファが表示されます。

(細かい使い方については、後でまとめようと思います)

(現状 r7rs-swank に不具合があり、M-x scheme-load-file が失敗します。
プルリクエスト https://github.com/ecraven/r7rs-swank/pull/11 を送っています)

--
＜作業について＞
作業のメモを以下に置いておきます。
https://gist.github.com/Hamayama/37a7c766dca2fd0f3ee42c0147530f94

大体は lisp-mode からのコピーですが、通信関係はけっこう調整が必要でした。
(Common Lisp の form を文字列に変換して送信しているところで、
Scheme には解釈できないリテラルに変換されていたり等)

現状、▲ が付いている項目は、未対応です。
あまり使える機能がありませんが。。。

補完については、処理系に問い合わせているので、大分優秀になりました。

--
＜コマンドについて＞
r7rs-swank サーバを導入しないと使えないのに、
scheme-slime 系のコマンドが、たくさん M-x の補完リストに出てくるのもどうかと思い、
`lem-scheme-mode:*use-scheme-slime*` で、コマンドの有効/無効を指定できるようにしました。
t で有効、nil で無効になります。
(scheme-mode.lisp の最後のところで、コマンドテーブルの削除/追加を行っています)

ただ、何も表示しないのも、存在自体を気づかれなくて残念だと思い、
`:auto` を指定したときには、scheme-slime と scheme-slime-connect だけ有効にするようにしました。
これらのコマンドを実行すると、他の scheme-slime 系のコマンドも有効になります。
(今のところデフォルトを `:auto` にしてあります)

scheme-slime コマンドを実行しなければ、
今まで通り、async-process による repl 起動になります。
(個人的には、軽量な async-process も気に入っています)

[r7rs-swank]:https://github.com/ecraven/r7rs-swank
