### PR TITLE
[lem-pdcurses] Use escape-delay variable

### DIFF
--- a/frontends/pdcurses/ncurses-pdcurseswin32.lisp
+++ b/frontends/pdcurses/ncurses-pdcurseswin32.lisp
@@ -1,5 +1,17 @@
 (in-package :lem-ncurses)
 
+;; escape key delay setting
+;;  On PDCurses, we often have to use escape key as an alternative to alt key
+;;  because some combination input with alt key doesn't work (e.g. M-< ).
+;;  Thus, we set escape-delay to a large value (1000 msec) by default.
+;;
+;;  However, if you use vi-mode, you might need to set it to a small value
+;;  by writing the following setting in init.lisp .
+;;    #+(and win32 lem-ncurses)
+;;    (setf (variable-value 'lem-ncurses::escape-delay :global) 100)
+;;
+(setf (variable-value 'escape-delay :global) 1000)
+
 ;; windows terminal type
 ;;   :mintty  : mintty  (winpty is needed)
 ;;   :conemu  : ConEmu  (experimental)
@@ -352,8 +364,7 @@
       (abort-code  (get-code "C-]"))
       (escape-code (get-code "escape"))
       (ctrl-key nil)
-      (alt-key  nil)
-      (esc-key  nil))
+      (alt-key  nil))
   (defun get-ch ()
     (let ((code          (getch-pad))
           (modifier-keys (charms/ll:PDC-get-key-modifiers)))
@@ -440,34 +451,40 @@
       code))
   (defun get-event ()
     (let ((code (get-ch)))
-      (cond ((= code -1)
-             ;; retry is necessary to exit lem normally
-             :retry)
-            ((= code resize-code)
-             ;; for resizing display
-             (setf (now-resizing) t)
-             :resize)
-            ((= code mouse-code)
-             ;; for mouse
-             (multiple-value-bind (bstate x y z id)
-                 (charms/ll:getmouse)
-               (declare (ignore z id))
-               (mouse-event-proc bstate x y)))
-            ((= code abort-code)
-             (setf esc-key nil)
-             :abort)
-            ((= code escape-code)
-             (setf esc-key t)
-             (get-key-from-name "escape"))
-            ((or alt-key esc-key)
-             (setf esc-key nil)
+      (cond
+        ((= code -1)
+         ;; retry is necessary to exit lem normally
+         :retry)
+        ((= code resize-code)
+         ;; for resizing display
+         (setf (now-resizing) t)
+         :resize)
+        ((= code mouse-code)
+         ;; for mouse
+         (multiple-value-bind (bstate x y z id)
+             (charms/ll:getmouse)
+           (declare (ignore z id))
+           (mouse-event-proc bstate x y)))
+        ((= code abort-code)
+         :abort)
+        ((= code escape-code)
+         ;; check if it is independent escape key input
+         (charms/ll:wtimeout *padwin* (variable-value 'escape-delay))
+         (setf code (get-ch))
+         (charms/ll:wtimeout *padwin* 0)
+         (if (= code -1)
+             (get-key-from-name "escape")
              (let ((key (get-key code)))
                (make-key :meta t
                          :sym (key-sym key)
-                         :ctrl (key-ctrl key))))
-            (t
-             (setf esc-key nil)
-             (get-key code))))))
+                         :ctrl (key-ctrl key)))))
+        (alt-key
+         (let ((key (get-key code)))
+           (make-key :meta t
+                     :sym (key-sym key)
+                     :ctrl (key-ctrl key))))
+        (t
+         (get-key code))))))
 
 ;; workaround for exit problem
 (defun input-loop (editor-thread)


### PR DESCRIPTION
- https://github.com/cxxxr/lem/pull/423 の escape-delay に対応しました。

- 今までは、Escape キーの入力があったときにフラグを立てて、
  次の入力を M-x として解釈するようにしていました。
  しかし、以下の問題がありました。
  (1) 単独の Escape キーを入力したあとに、何かキーを押すと M-x になってしまう
  (2) C-x M-x のようなキーバインドを入力できない (単独の Escape 入力が間に挟まるため)

- 今回、フラグを削除してタイマーのみにしました。
  (lem-ncurses と同じにしました)

- ただ、現状の PDCurses には、
  Alt キーと同時押しで入力できない組み合わせがあり (M-<, M->, M-; 等)、
  それらを入力するには Escape キーとの組み合わせが必要になります。

- そのときにタイムアウトが 100 msec だと、ちょっと入力できなかったため、
  デフォルト値は 1000 msec にしました。

- vi-mode を使用する等で、短い値にしたい場合には、
  init.lisp に以下のように記述してください。
  ```
  #+(and win32 lem-ncurses)
  (setf (variable-value 'lem-ncurses::escape-delay :global) 100)
  ```

- あと、いろいろテストしていて、winpty に不具合が見つかったため、報告しました。
  https://github.com/rprichard/winpty/pull/175
  (現状、mintty+winpty を使用していて、1行目の2～8桁目にカーソルを置いて、
  Escape キーを押すと、Escape キーがうまく機能しなくなります。
  復旧するには、lem (つまり winpty) の再起動が必要です。。。)
