### PR TITLE
[language-mode] Change find-definitions jump behavior

### DIFF
--- a/lib/core/language-mode.lisp
+++ b/lib/core/language-mode.lisp
@@ -270,7 +270,11 @@
       (setf locations (uiop:ensure-list locations))
       (if (null (rest locations))
           (progn
-            (go-to-location (first locations) #'switch-to-buffer)
+            (go-to-location (first locations)
+                            (lambda (buffer)
+                              (alexandria:when-let ((windows (get-buffer-windows buffer)))
+                                (setf (current-window) (car windows)))
+                              (switch-to-buffer buffer)))
             (jump-highlighting))
           (let ((prev-file nil))
             (with-sourcelist (sourcelist "*definitions*")


### PR DESCRIPTION
- M-x find-definitions で、定義位置にジャンプするときに、
  すでに表示中のバッファがあれば、そこにジャンプするようにしました。
  (画面分割時に、同じバッファを2個表示することがないように)
