### PR TITLE
Workaround for long line display

### DIFF
--- a/lib/core/interface.lisp
+++ b/lib/core/interface.lisp
@@ -484,7 +484,7 @@
     (tagbody :retry
       (setf start 0)
       (setf point-y point-y0)
-      (loop :with omitted := 0
+      (loop :with omitted := nil
             :for i := (wide-index (car str/attributes)
                                   (1- screen-width)
                                   :start start)
@@ -497,7 +497,7 @@
                        ;; workaround for long line display
                        ;;  (omit previous over-h lines)
                        (decf over-h)
-                       (when (= omitted 0) (setf omitted 1))
+                       (setf omitted t)
                        (setf start i))
                       (t
                        (disp-print-line screen point-y str/attributes t
@@ -506,9 +506,8 @@
                        (disp-print-line screen point-y
                                         ;; workaround for long line display
                                         ;;  (display omitted line character)
-                                        (if (= omitted 1)
-                                            (progn (setf omitted 2)
-                                                   omitted-line-str/attributes)
+                                        (if omitted
+                                            omitted-line-str/attributes
                                             truncate-str/attributes)
                                         t
                                         :start-x (+ start-x (1- screen-width)))

--- a/lib/core/interface.lisp
+++ b/lib/core/interface.lisp
@@ -518,18 +518,16 @@
       ;;  (The real cursor-y is determined only after printing all lines.
       ;;   Thus, we need to check the real cursor-y here and retry if
       ;;   necessary.)
-      (alexandria:when-let
-          ((attr (and long-line-display
-                      first-time
-                      (>= point-y (screen-height screen))
-                      (car (lem-base::subseq-elements (cdr str/attributes)
-                                                      start (1+ start))))))
-        (destructuring-bind (s e attr) attr
-          (declare (ignore s e))
-          (when (eq attr 'cursor)
-            (setf over-h (1+ over-h0))
-            (setf first-time nil)
-            (go :retry)))))
+      (when (and long-line-display
+                 first-time
+                 (>= point-y (screen-height screen)))
+        (dolist (attr-1 (lem-base::subseq-elements (cdr str/attributes)
+                                                   start (1+ start)))
+          (destructuring-bind (s e attr) attr-1
+            (when (and (= s 0) (= e 1) (eq attr 'cursor))
+              (setf over-h (1+ over-h0))
+              (setf first-time nil)
+              (go :retry))))))
 
     point-y))
 

--- a/lib/core/window.lisp
+++ b/lib/core/window.lisp
@@ -359,7 +359,8 @@
                (declare (ignore arg))
                (incf offset)))
       (map-region (window-view-point window)
-                  (window-buffer-point window)
+                  ;;(window-buffer-point window)
+                  (window-point window)
                   (lambda (string lastp)
                     (declare (ignore lastp))
                     (map-wrapping-line window
@@ -368,7 +369,8 @@
       offset)))
 
 (defun window-cursor-y-not-wrapping (window)
-  (count-lines (window-buffer-point window)
+  (count-lines ;;(window-buffer-point window)
+               (window-point window)
                (window-view-point window)))
 
 (defun window-cursor-y (window)


### PR DESCRIPTION
折り返し時に画面の高さを超えるような長い行を表示したときに、
うまく表示や編集ができない件に対応しようとしてみたものです。

画面全体の表示をずらすのは、難しかったため、
最下行だけ表示をずらすようにしてみました。

(カーソルが画面の高さよりも下に移動したときに、
最下行だけ表示を上にずらします。ずれた分は非表示になります)

ずらした行の右端には `\` 記号の代わりに `<` 記号を表示します。

(この記号があった場合、最下行の先頭から折り返し N個 (N>0) の範囲で、
非表示になっている部分があることを示します)

多くのユーザーが求めているものとは違うと思いますが。。。
最低限の確認や編集は可能になるかと。

**本機能を使用する場合、~/.lem/init.lisp 内に以下のように記述してください。**
(デフォルトは nil (無効) にしてあります)
```
;; workaround for long line display
(setf (variable-value 'lem::long-line-display :global) t)
```

現状、以下の問題点があります。

(1) 最下行に表示されない部分があることが、分かりにくい

(2) カーソルが常に画面の一番下にあるため、編集がやりにくい

(3) previous/next-line (C-p/C-n) にしか対応していない
    previous/next-page (M-v/C-v) には非対応 (たくさんスクロールしてしまう)
    scroll-up/down (C-Up/Down) には非対応 (ある程度スクロールするとジャンプしてしまう)
    (C-u 100 C-n で 100回下に移動する等は一応できますが。。。)

(4) マウスでカーソルを移動すると、行頭の表示に戻ってしまう

(5) 非表示の部分が多くなると、かなり遅くなる

(6) isearch-forward (C-s) は使えるが、これも非表示の部分が多くなると、すごく遅い
