### PR TITLE
Fixed "target pattern contains no `%'" error from Make.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -45,4 +45,4 @@ clean-local:
 	ros -L ${LISP_IMPL} delete dump lem-ncurses|true
 
 all-sbcl:
-    sbcl --eval '(asdf:make :lem/executable)' --quit
+	sbcl --eval '(asdf:make :lem/executable)' --quit


### PR DESCRIPTION
Indentation was wrong.

This pull closes issue https://github.com/cxxxr/lem/issues/449