### PR TITLE
Added ability to output infmation into the log.

### DIFF
--- a/lib/core/lem-core.asd
+++ b/lib/core/lem-core.asd
@@ -11,7 +11,8 @@
                "cl-fad"
                "lem-base"
                "lem-encodings"
-               "lem-lisp-syntax")
+               "lem-lisp-syntax"
+               "log4cl")
   :serial t
   :components ((:file "history")
                (:file "package")

--- a/modes/lisp-mode/lisp-mode.lisp
+++ b/modes/lisp-mode/lisp-mode.lisp
@@ -120,6 +120,7 @@
 
 (defun self-connect ()
   (let ((port (random-port)))
+    (log:debug "Starting internal SWANK and connecting to it" swank:*communication-style*)
     (let ((swank::*swank-debug-p* nil))
       (swank:create-server :port port))
     (slime-connect *localhost* port nil)


### PR DESCRIPTION
Two new options were added to control if log should be written to the file:

* `--log-filename /tmp/lem.log` - this will output `INFO`, `WARNING` and `ERROR` messages
  to the file.
* `--debug` - with this flag Lem will output also `DEBUG` messages to the log.
  This flag should be used along with `--log-filename`.