### PR TITLE
Fixed an issue when connection to swank didn't initialized propertly

### DIFF
--- a/modes/lisp-mode/lisp-mode.lisp
+++ b/modes/lisp-mode/lisp-mode.lisp
@@ -121,7 +121,7 @@
 (defun self-connect ()
   (let ((port (random-port)))
     (let ((swank::*swank-debug-p* nil))
-      (swank:create-server :port port))
+      (swank:create-server :port port :style :spawn))
     (slime-connect *localhost* port nil)
     (update-buffer-package)
     (setf *self-connected-port* port)))


### PR DESCRIPTION
The root of the problem was that on OSX `swank:*communication-style*` is equal to `:fd-handler`
for some reason. In this case `swank:create-server` does not start threads which
accept connections on TCP port and process incoming messages.

To make it work propertly, we need to specify that communication style is `:spawn`.

This commit closes issue https://github.com/cxxxr/lem/issues/411.