### PR TITLE
Fix #452 (Workaround for long line display v2)

### DIFF
--- a/lib/core/command.lisp
+++ b/lib/core/command.lisp
@@ -344,12 +344,20 @@
 (define-key *global-keymap* "C-v" 'next-page)
 (define-key *global-keymap* "PageDown" 'next-page)
 (define-command next-page (&optional n) ("P")
-  (scroll-down (or n (1- (window-height (current-window))))))
+  (if n
+      (scroll-down n)
+      (progn
+        (next-line (1- (window-height (current-window))))
+        (window-recenter (current-window)))))
 
 (define-key *global-keymap* "M-v" 'previous-page)
 (define-key *global-keymap* "PageUp" 'previous-page)
 (define-command previous-page (&optional n) ("P")
-  (scroll-up (or n (1- (window-height (current-window))))))
+  (if n
+      (scroll-up n)
+      (progn
+        (previous-line (1- (window-height (current-window))))
+        (window-recenter (current-window)))))
 
 (defun delete-while-whitespaces (ignore-newline-p)
   (let ((n (skip-chars-forward (current-point)

--- a/lib/core/window-command.lisp
+++ b/lib/core/window-command.lisp
@@ -240,9 +240,6 @@
   (cond
     ((minusp n)
      (scroll-up (- n)))
-    ((last-line-p (window-view-point (current-window)))
-     (next-line 0) ; to preserve *next-line-prev-column*
-     (editor-error "End of buffer"))
     (t
      (window-scroll (current-window) n)
      (let ((offset (window-offset-view (current-window))))
@@ -257,9 +254,6 @@
   (cond
     ((minusp n)
      (scroll-down (- n)))
-    ((first-line-p (window-view-point (current-window)))
-     (previous-line 0) ; to preserve *next-line-prev-column*
-     (editor-error "Beginning of buffer"))
     (t
      (window-scroll (current-window) (- n))
      (let ((offset (window-offset-view (current-window))))

--- a/lib/core/window-command.lisp
+++ b/lib/core/window-command.lisp
@@ -245,11 +245,7 @@
        (buffer-end (window-view-point (current-window)))
        (backward-line-wrap (window-view-point (current-window))
                            (current-window) t))
-     (let ((offset (window-offset-view (current-window))))
-       (if (< offset 0)
-           (next-line (- offset))
-           (next-line 0) ; to preserve *next-line-prev-column*
-           )))))
+     (next-line (- (window-offset-view (current-window)))))))
 
 (define-key *global-keymap* "C-Up" 'scroll-up)
 (define-key *global-keymap* "M-Up" 'scroll-up)
@@ -260,11 +256,7 @@
     (t
      (unless (window-scroll (current-window) (- n))
        (buffer-start (window-view-point (current-window))))
-     (let ((offset (window-offset-view (current-window))))
-       (if (> offset 0)
-           (previous-line offset)
-           (previous-line 0) ; to preserve *next-line-prev-column*
-           )))))
+     (previous-line (window-offset-view (current-window))))))
 
 (define-other-window-command find-file "FFind File Other Window: ")
 (define-key *global-keymap* "C-x 4 f" 'find-file-other-window)

--- a/lib/core/window-command.lisp
+++ b/lib/core/window-command.lisp
@@ -241,7 +241,10 @@
     ((minusp n)
      (scroll-up (- n)))
     (t
-     (window-scroll (current-window) n)
+     (unless (window-scroll (current-window) n)
+       (buffer-end (window-view-point (current-window)))
+       (backward-line-wrap (window-view-point (current-window))
+                           (current-window) t))
      (let ((offset (window-offset-view (current-window))))
        (if (< offset 0)
            (next-line (- offset))
@@ -255,7 +258,8 @@
     ((minusp n)
      (scroll-down (- n)))
     (t
-     (window-scroll (current-window) (- n))
+     (unless (window-scroll (current-window) (- n))
+       (buffer-start (window-view-point (current-window))))
      (let ((offset (window-offset-view (current-window))))
        (if (> offset 0)
            (previous-line offset)

--- a/lib/core/window.lisp
+++ b/lib/core/window.lisp
@@ -417,7 +417,9 @@
          (window-wrapping-offset window
                                  (window-view-point window)
                                  (window-buffer-point window))
-         (if (cursor-goto-next-line-p (window-buffer-point window) window)
+         (if (and (point< (window-view-point window)
+                          (window-buffer-point window))
+                  (cursor-goto-next-line-p (window-buffer-point window) window))
              1 0))))
 
 (defun forward-line-wrap (point window)

--- a/lib/core/window.lisp
+++ b/lib/core/window.lisp
@@ -605,15 +605,15 @@
 
 (defun window-scroll (window n)
   (screen-modify (window-screen window))
-  (if *use-new-vertical-move-function*
-      (if (plusp n)
-          (window-scroll-down-n window n)
-          (window-scroll-up-n window (- n)))
-      (dotimes (_ (abs n))
-        (if (plusp n)
-            (window-scroll-down window)
-            (window-scroll-up window))))
-  (run-hooks *window-scroll-functions* window))
+  (prog1 (if *use-new-vertical-move-function*
+             (if (plusp n)
+                 (window-scroll-down-n window n)
+                 (window-scroll-up-n window (- n)))
+             (dotimes (_ (abs n))
+               (if (plusp n)
+                   (window-scroll-down window)
+                   (window-scroll-up window))))
+    (run-hooks *window-scroll-functions* window)))
 
 (defun window-offset-view (window)
   (if (point< (window-buffer-point window)


### PR DESCRIPTION
#452 の不具合修正になります。

(参照: https://github.com/cxxxr/lem/pull/452#issuecomment-575975609 )

(1) 一行しかない場合は上下のスクロールができない(論理行でみると次の行が無いことが原因?)
→ scroll-down,scroll-up の処理を修正しました
   (下手にメッセージを出そうとして、失敗していました)

(2) window-view-pointが論理行で行頭にない、かつカーソルが1行目の1列目にあるときwindow-cursor-yが1で0ではない(1行目2列目からは0になる)
→ window-cursor-y を修正しました
   (これは、よく見つかりましたね。。。)

(3) next-page,previous-pageでスクロール後、カーソルのいる行が前と変わっている(前は画面の真ん中になっていた)
→ next-page,previous-page の処理を修正しました
   (n を明示的に指定した場合とは処理が異なりますが、前と同じにはなったかと。。。)
