### PR TITLE
Initialize listener-point when entering listener-mode

### DIFF
--- a/lib/core/listener-mode.lisp
+++ b/lib/core/listener-mode.lisp
@@ -39,7 +39,9 @@
   (setf (variable-value 'enable-syntax-highlight) nil)
   (unless (%listener-history)
     (setf (%listener-history)
-          (lem.history:make-history))))
+          (lem.history:make-history)))
+  (unless (%listener-point (current-buffer))
+    (listener-update-point)))
 
 (define-key *listener-mode-keymap* "Return" 'listener-return)
 (define-key *listener-mode-keymap* "M-p" 'listener-prev-input)

--- a/modes/scheme-mode/repl.lisp
+++ b/modes/scheme-mode/repl.lisp
@@ -7,7 +7,6 @@
     ((or (eq (scheme-repl-type :kind :current) :scheme-process)
          (eq (scheme-repl-type :kind :current) :scheme-slime))
      (lem.listener-mode:listener-mode t)
-     (lem.listener-mode:listener-update-point)
      (when (eq (scheme-repl-type :kind :current) :scheme-process)
        ;; disable listener-mode functions
        (setf (variable-value 'lem.listener-mode:listener-set-prompt-function)


### PR DESCRIPTION
listner-mode に入るときに、
listener-point が初期化されていなければ、初期化するようにしました。

これは、repl の接続先が起動できなかった場合に、
Enter キーを押すたびに、listener-return のところでエラーが出ることを防ぎます。
