### PR TITLE
[lem-pdcurses] Fix isearch and mouse combination error

### DIFF
--- a/frontends/pdcurses/ncurses-pdcurseswin32.lisp
+++ b/frontends/pdcurses/ncurses-pdcurseswin32.lisp
@@ -470,6 +470,8 @@
          (multiple-value-bind (bstate x y z id)
              (charms/ll:getmouse)
            (declare (ignore z id))
+           ;; exit isearch-mode
+           (send-event (make-key :sym "NopKey"))
            (mouse-event-proc bstate x y)))
         ((= code abort-code)
          :abort)

--- a/lib/core/command.lisp
+++ b/lib/core/command.lisp
@@ -4,6 +4,7 @@
           exit-lem
           quick-exit
           keyboard-quit
+          nop-command
           self-insert-before-hook
           self-insert-after-hook
           self-insert
@@ -82,6 +83,9 @@
 (define-key *global-keymap* "C-g" 'keyboard-quit)
 (define-command keyboard-quit () ()
   (error 'editor-abort))
+
+(define-key *global-keymap* "NopKey" 'nop-command)
+(define-command nop-command () ())
 
 (define-editor-variable self-insert-before-hook '())
 (define-editor-variable self-insert-after-hook '())

--- a/lib/core/key.lisp
+++ b/lib/core/key.lisp
@@ -14,7 +14,7 @@
 
 (defparameter *named-key-syms*
   '("Backspace" "Delete" "Down" "End" "Escape" "F0" "F1" "F10" "F11" "F12" "F2" "F3" "F4" "F5" "F6" "F7" "F8" "F9"
-    "Home" "Left" "PageDown" "PageUp" "Return" "Right" "Space" "Tab" "Up"))
+    "Home" "Left" "NopKey" "PageDown" "PageUp" "Return" "Right" "Space" "Tab" "Up"))
 
 (defun named-key-sym-p (key-sym)
   (find key-sym *named-key-syms* :test #'string=))
@@ -149,6 +149,7 @@
 (setf (key-to-character (make-key :shift t :sym "PageDown")) (code-char 396))
 (setf (key-to-character (make-key :shift t :sym "PageUp")) (code-char 398))
 (setf (key-to-character (make-key :shift t :sym "Right")) (code-char 402))
+(setf (key-to-character (make-key :sym "NopKey")) (code-char 600)) ; used for nop-command
 
 (loop :for code :from #x21 :below #x7F
       :do (setf (key-to-character (make-key :sym (string (code-char code)))) (code-char code)))


### PR DESCRIPTION
isearch (C-s) と マウス操作 と C-g の組み合わせで、落ちることがありました。
直し方がよくないかもしれませんが、まずは挙げておきます。

＜現象＞
2画面分割表示 (C-x 2) にして、各画面で isearch (C-s) で検索した後に、
C-g を押すと落ちることがあった。
カレントウィンドウの切り換えを、マウスクリックで行っていた場合にのみ発生する。

＜原因＞
マウスクリックでカレントウィンドウの切り換えを行うと、
キー入力イベントが発生しないため、isearch-mode を抜けない。
その後、C-g を押すと、isearch-abort が呼ばれて、
他のウィンドウのポインタ位置 (`*isearch-start-point*`) に戻ろうとして
エラーになる (Lem が終了する)。

＜対策＞
ダミーのキー (NopKey) と 何もしないコマンド (nop-command) を登録して、
マウスイベントのところで呼び出すようにした。
これによって、マウスクリック時に isearch-mode を抜けるようにした。
