### PR TITLE
Set *print-readably* to nil in with-swank-syntax

### DIFF
--- a/modes/lisp-mode/swank-protocol.lisp
+++ b/modes/lisp-mode/swank-protocol.lisp
@@ -41,7 +41,8 @@
 (defmacro with-swank-syntax (() &body body)
   `(with-standard-io-syntax
      (let ((*package* (find-package :swank-io-package))
-           (*print-case* :downcase))
+           (*print-case* :downcase)
+           (*print-readably* nil))
        ,@body)))
 
 ;;; Encoding and decoding messages


### PR DESCRIPTION
Issue #460 の対応になります。
(SBCL 版の Lem と CCL 版の swank-server を接続すると、#A の非互換のためエラーになる件)

modes/lisp-mode/swank-protocol.lisp の with-swank-syntax に
`(*print-readably* nil)` を追加しました。

https://github.com/slime/slime/blob/1761172817d2e1a8b48c216bf0d261eb277ae562/swank.lisp
を確認したところ、
`*print-readably*` を t にしているケースはないようでした。
(with-standard-io-syntax 内も)
