### PR TITLE
Improve mouse control

### DIFF
--- a/contrib/mouse-sgr1006/main.lisp
+++ b/contrib/mouse-sgr1006/main.lisp
@@ -6,15 +6,24 @@
 (defparameter *message-on-mouse-event* nil)
 
 (defvar *dragging-window* ())
+(defvar *min-cols*  5)
+(defvar *min-lines* 1)
+(defvar *wheel-scroll-size* 3)
+
+(defun get-window-rect (window)
+  (values (lem:window-x     window)
+          (lem:window-y     window)
+          (lem:window-width window)
+          (- (lem:window-height window)
+             (if (lem::window-use-modeline-p window) 1 0))))
 
 (defun move-to-cursor (window x y)
   (lem:move-point (lem:current-point) (lem::window-view-point window))
   (lem:move-to-next-virtual-line (lem:current-point) y)
   (lem:move-to-virtual-line-column (lem:current-point) x))
 
-(defun parse-mouse-event ()
-  (let ((msg (loop :for c := (prog1 (code-char (charms/ll:getch))
-                               (charms/ll:timeout -1))
+(defun parse-mouse-event (getch-fn)
+  (let ((msg (loop :for c := (code-char (funcall getch-fn))
                    :with result
                    :with part
                    :until (or (char= c #\m)
@@ -28,53 +37,110 @@
                    :do (push c part)
                    :finally (return (cons c (reverse #1#))))))
     (lambda ()
-      (when (zerop (second msg))
-        (cond ((and (eql (second msg) 0)
-                    (eql (first msg) #\M)) ;; button-1 down
-               (find-if (lambda(o)
-                          (let ((x (lem:window-x o))
-                                (w (lem:window-width o))
-                                (y (lem:window-y o))
-                                (h (lem:window-height o)))
-                            (or
-                             (and (< x (third msg) (+ 1 x w))
-                                  (= y (fourth msg))
-                                  (setf *dragging-window* (list o 'y)))
-                             (and (= x (third msg))
-                                  (< y (fourth msg) (+ -1 y h))
-                                  (setf *dragging-window* (list o 'x)))
-                             (and (< x (third msg) (+ 1 x w))
-                                  (< y (fourth msg) (+ -1 y h))
-                                  (lem:send-event
-                                   (lambda ()
-                                     (setf (lem:current-window) o)
-                                     (move-to-cursor o
-                                                     (- (third msg) x 1)
-                                                     (- (fourth msg) y 1))
-                                     (lem:redraw-display)))))))
-                        (lem:window-list)))
-              ((and (eql (second msg) 0)  ;; button-1 up
-                    (eql (first msg) #\m))
-               (when (windowp (first *dragging-window*))
-                 (if (eql (second *dragging-window*) 'x)
-                     (lem:shrink-window-horizontally
-                      (- (lem:window-x (first *dragging-window*))
-                         (first (cddr msg))))
-                     (lem:shrink-window
-                      (- (lem:window-y (first *dragging-window*))
-                         (second (cddr msg))))))
-               (when (first *dragging-window*)
-                 (setf *dragging-window*
-                       (list nil (cddr msg) *dragging-window*))))))
-      (when *message-on-mouse-event*
-        (lem:message "mouse:~S" msg))
+      (multiple-value-bind (bstate bno x1 y1)
+          (apply #'values msg)
+        ;; convert mouse position from 1-origin to 0-origin
+        (decf x1)
+        (decf y1)
+        ;; check mouse status
+        (when (or (and (not lem::*floating-windows*)
+                       (eql bno 0)      ; button-1
+                       (or (eql bstate #\m)
+                           (eql bstate #\M)))
+                  (and (or (eql bno 64) ; wheel
+                           (eql bno 65))
+                       (eql bstate #\M)))
+          ;; send a dummy key event to exit isearch-mode
+          (lem:send-event (lem:make-key :sym "NopKey")))
+        ;; send actual mouse event
+        (lem:send-event (parse-mouse-event-sub bstate bno x1 y1))))))
+
+(defun parse-mouse-event-sub (bstate bno x1 y1)
+  (lambda ()
+    ;; process mouse event
+    (cond
+      ;; button-1 down
+      ((and (not lem::*floating-windows*)
+            (eql bno 0)
+            (eql bstate #\M))
+       (find-if
+        (lambda(o)
+          (multiple-value-bind (x y w h) (get-window-rect o)
+            (cond
+              ;; vertical dragging window
+              ((and (= y1 (- y 1)) (<= x x1 (+ x w -1)))
+               (setf *dragging-window* (list o 'y))
+               t)
+              ;; horizontal dragging window
+              ((and (= x1 (- x 1)) (<= y y1 (+ y h -1)))
+               (setf *dragging-window* (list o 'x))
+               t)
+              ;; move cursor
+              ((and (<= x x1 (+ x w -1)) (<= y y1 (+ y h -1)))
+               (setf (lem:current-window) o)
+               (move-to-cursor o (- x1 x) (- y1 y))
+               (lem:redraw-display)
+               t)
+              (t nil))))
+        ;; include active minibuffer window
+        (if (lem::active-minibuffer-window)
+            (cons (lem::active-minibuffer-window) (lem:window-list))
+            (lem:window-list))))
+      ;; button-1 up
+      ((and (eql bno 0)
+            (eql bstate #\m))
+       (let ((o-orig (lem:current-window))
+             (o (first *dragging-window*)))
+         (when (windowp o)
+           (multiple-value-bind (x y w h) (get-window-rect o)
+             (declare (ignore x y))
+             (cond
+               ;; vertical dragging window
+               ((eq (second *dragging-window*) 'y)
+                (let ((vy (- (- (lem:window-y o) 1) y1)))
+                  ;; this check is incomplete if 3 or more divisions exist
+                  (when (and (not lem::*floating-windows*)
+                             (>= y1       *min-lines*)
+                             (>= (+ h vy) *min-lines*))
+                    (setf (lem:current-window) o)
+                    (lem:grow-window vy)
+                    (setf (lem:current-window) o-orig)
+                    (lem:redraw-display))))
+               ;; horizontal dragging window
+               (t
+                (let ((vx (- (- (lem:window-x o) 1) x1)))
+                  ;; this check is incomplete if 3 or more divisions exist
+                  (when (and (not lem::*floating-windows*)
+                             (>= x1       *min-cols*)
+                             (>= (+ w vx) *min-cols*))
+                    (setf (lem:current-window) o)
+                    (lem:grow-window-horizontally vx)
+                    (setf (lem:current-window) o-orig)
+                    (lem:redraw-display))))
+               )))
+         (when o
+           (setf *dragging-window*
+                 (list nil (list x1 y1) *dragging-window*)))))
+      ;; wheel up
+      ((and (eql bno 64)
+            (eql bstate #\M))
+       (lem:scroll-up *wheel-scroll-size*)
+       (lem:redraw-display))
+      ;; wheel down
+      ((and (eql bno 65)
+            (eql bstate #\M))
+       (lem:scroll-down *wheel-scroll-size*)
+       (lem:redraw-display))
+      )
+    (when *message-on-mouse-event*
+      (lem:message "mouse:~s ~s ~s ~s" bstate bno x1 y1)
       (lem:redraw-display))))
 
 (defvar *enable-hook* '())
 (defvar *disable-hook* '())
 
 (defun enable-hook ()
-  (format *terminal-io* "~A[?1000h~A[?1002h~A[?1006h~%" #\esc #\esc #\esc)
+  (format lem::*terminal-io-saved* "~A[?1000h~A[?1002h~A[?1006h~%" #\esc #\esc #\esc)
   (ignore-errors
    (dolist (window (lem:window-list))
      (lem::screen-clear (lem::window-screen window)))
@@ -82,7 +148,7 @@
   (run-hooks *enable-hook*))
 
 (defun disable-hook ()
-  (format *terminal-io* "~A[?1006l~A[?1002l~A[?1000l~%" #\esc #\esc #\esc)
+  (format lem::*terminal-io-saved* "~A[?1006l~A[?1002l~A[?1000l~%" #\esc #\esc #\esc)
   (ignore-errors
    (dolist (window (lem:window-list))
      (lem::screen-clear (lem::window-screen window)))
@@ -97,7 +163,9 @@
 (defun enable-mouse-sgr-1006-mode ()
   (mouse-sgr-1006-mode t))
 
-(add-hook *after-init-hook* 'enable-mouse-sgr-1006-mode)
+(defun disable-mouse-sgr-1006-mode ()
+  (mouse-sgr-1006-mode nil))
 
-(eval-when (:load-toplevel)
-  (enable-mouse-sgr-1006-mode))
+(add-hook *after-init-hook* 'enable-mouse-sgr-1006-mode)
+(add-hook *exit-editor-hook* 'disable-mouse-sgr-1006-mode)
+

--- a/contrib/mouse-sgr1006/main.lisp
+++ b/contrib/mouse-sgr1006/main.lisp
@@ -93,11 +93,10 @@
              (o (first *dragging-window*)))
          (when (windowp o)
            (multiple-value-bind (x y w h) (get-window-rect o)
-             (declare (ignore x y))
              (cond
                ;; vertical dragging window
                ((eq (second *dragging-window*) 'y)
-                (let ((vy (- (- (lem:window-y o) 1) y1)))
+                (let ((vy (- (- y 1) y1)))
                   ;; this check is incomplete if 3 or more divisions exist
                   (when (and (not lem::*floating-windows*)
                              (>= y1       *min-lines*)
@@ -108,7 +107,7 @@
                     (lem:redraw-display))))
                ;; horizontal dragging window
                (t
-                (let ((vx (- (- (lem:window-x o) 1) x1)))
+                (let ((vx (- (- x 1) x1)))
                   ;; this check is incomplete if 3 or more divisions exist
                   (when (and (not lem::*floating-windows*)
                              (>= x1       *min-cols*)

--- a/contrib/mouse-sgr1006/main.lisp
+++ b/contrib/mouse-sgr1006/main.lisp
@@ -168,3 +168,5 @@
 (add-hook *after-init-hook* 'enable-mouse-sgr-1006-mode)
 (add-hook *exit-editor-hook* 'disable-mouse-sgr-1006-mode)
 
+(eval-when (:load-toplevel)
+  (enable-mouse-sgr-1006-mode))

--- a/frontends/ncurses/ncurses.lisp
+++ b/frontends/ncurses/ncurses.lisp
@@ -1,6 +1,9 @@
 (defpackage :lem-ncurses
   (:use :cl :lem)
-  (:export ;; ncurses-pdcurseswin32.lisp
+  (:export ;; ncurses.lisp
+           :escape-delay
+           :getch
+           ;; ncurses-pdcurseswin32.lisp
            :input-polling-interval))
 (in-package :lem-ncurses)
 
@@ -227,15 +230,21 @@
               (setf (lem::attribute-%internal-value attribute) bits)
               bits)))))
 
-;; XXX: see ncurses-pdcurseswin32.lisp:getch-pad
+;; for input
+;;  (we don't use stdscr for input because it calls wrefresh implicitly
+;;   and causes the display confliction by two threads)
 (defvar *padwin* nil)
 (defun getch ()
   (unless *padwin*
     (setf *padwin* (charms/ll:newpad 1 1))
     (charms/ll:keypad *padwin* 1)
-    ;; timeout setting is necessary to exit lem normally
     (charms/ll:wtimeout *padwin* -1))
   (charms/ll:wgetch *padwin*))
+(defmacro with-getch-input-timeout ((time) &body body)
+  `(progn
+     (charms/ll:wtimeout *padwin* ,time)
+     (unwind-protect (progn ,@body)
+       (charms/ll:wtimeout *padwin* -1))))
 
 (defun get-key (code)
   (let* ((char (let ((nbytes (utf8-bytes code)))
@@ -243,8 +252,9 @@
                    (code-char code)
                    (let ((vec (make-array nbytes :element-type '(unsigned-byte 8))))
                      (setf (aref vec 0) code)
-                     (loop :for i :from 1 :below nbytes
-                           :do (setf (aref vec i) (getch)))
+                     (with-getch-input-timeout (100)
+                       (loop :for i :from 1 :below nbytes
+                             :do (setf (aref vec i) (getch))))
                      (handler-case (schar (babel:octets-to-string vec) 0)
                        (babel-encodings:invalid-utf8-continuation-byte ()
                          (code-char code)))))))
@@ -324,19 +334,22 @@
                 ((= code resize-code) :resize)
                 ((= code abort-code) :abort)
                 ((= code escape-code)
-                 (charms/ll:wtimeout *padwin* (variable-value 'escape-delay))
-                 (let ((code (prog1 (getch)
-                               (charms/ll:wtimeout *padwin* -1))))
+                 (let ((code (with-getch-input-timeout
+                                 ((variable-value 'escape-delay))
+                               (getch))))
                    (cond ((= code -1)
                           (get-key-from-name "escape"))
                          ((= code #.(char-code #\[))
-                          (case (getch)
-                            (#.(char-code #\<)
-                               ;;sgr(1006)
-                               (uiop:symbol-call :lem-mouse-sgr1006 :parse-mouse-event))
-                            (#.(char-code #\1)
-                               (csi\[1))
-                            (t (get-key-from-name "escape"))))
+                          (with-getch-input-timeout (100)
+                            (case (getch)
+                              (#.(char-code #\<)
+                                 ;;sgr(1006)
+                                 (uiop:symbol-call :lem-mouse-sgr1006
+                                                   :parse-mouse-event
+                                                   #'getch))
+                              (#.(char-code #\1)
+                                 (csi\[1))
+                              (t (get-key-from-name "escape")))))
                          (t
                           (let ((key (get-key code)))
                             (make-key :meta t

--- a/frontends/ncurses/ncurses.lisp
+++ b/frontends/ncurses/ncurses.lisp
@@ -2,7 +2,6 @@
   (:use :cl :lem)
   (:export ;; ncurses.lisp
            :escape-delay
-           :getch
            ;; ncurses-pdcurseswin32.lisp
            :input-polling-interval))
 (in-package :lem-ncurses)

--- a/frontends/pdcurses/ncurses-pdcurseswin32.lisp
+++ b/frontends/pdcurses/ncurses-pdcurseswin32.lisp
@@ -341,11 +341,10 @@
                (o (first *dragging-window*)))
            (when (windowp o)
              (multiple-value-bind (x y w h) (mouse-get-window-rect o)
-               (declare (ignore x y))
                (cond
                  ;; vertical dragging window
                  ((eq (second *dragging-window*) 'y)
-                  (let ((vy (- (- (lem:window-y o) 1) y1)))
+                  (let ((vy (- (- y 1) y1)))
                     ;; this check is incomplete if 3 or more divisions exist
                     (when (and (not lem::*floating-windows*)
                                (>= y1       *min-lines*)
@@ -356,7 +355,7 @@
                       (lem:redraw-display))))
                  ;; horizontal dragging window
                  (t
-                  (let ((vx (- (- (lem:window-x o) 1) cur-x)))
+                  (let ((vx (- (- x 1) cur-x)))
                     ;; this check is incomplete if 3 or more divisions exist
                     (when (and (not lem::*floating-windows*)
                                (>= cur-x    *min-cols*)

--- a/frontends/pdcurses/ncurses-pdcurseswin32.lisp
+++ b/frontends/pdcurses/ncurses-pdcurseswin32.lisp
@@ -141,6 +141,7 @@
   (defun input-polling-interval ()
     polling-interval)
   (defun (setf input-polling-interval) (v)
+    (when (<= v 0) (setf v 0.001))
     (setf polling-interval v)
     (cond
       ((< v 0.01)
@@ -216,10 +217,11 @@
 
 ;; mouse function
 (defun mouse-get-window-rect (window)
-  (values (lem:window-x      window)
-          (lem:window-y      window)
-          (lem:window-width  window)
-          (lem:window-height window)))
+  (values (lem:window-x     window)
+          (lem:window-y     window)
+          (lem:window-width window)
+          (- (lem:window-height window)
+             (if (lem::window-use-modeline-p window) 1 0))))
 ;; for mintty and ConEmu
 ;; get mouse disp-x for pointing wide characters properly
 (defun mouse-get-disp-x (view x y)
@@ -283,14 +285,28 @@
   (lem:move-to-virtual-line-column (lem:current-point) x))
 (defun mouse-event-proc (bstate x1 y1)
   (lambda ()
+    ;; check mouse status
+    (when (or (and (not lem::*floating-windows*)
+                   (logtest bstate (logior charms/ll:BUTTON1_PRESSED
+                                           charms/ll:BUTTON1_CLICKED
+                                           charms/ll:BUTTON1_DOUBLE_CLICKED
+                                           charms/ll:BUTTON1_TRIPLE_CLICKED
+                                           charms/ll:BUTTON1_RELEASED)))
+              (logtest bstate (logior charms/ll:BUTTON4_PRESSED
+                                      charms/ll:BUTTON5_PRESSED)))
+      ;; send a dummy key event to exit isearch-mode
+      (lem:send-event (lem:make-key :sym "NopKey")))
+    ;; send actual mouse event
+    (lem:send-event (mouse-event-proc-sub bstate x1 y1))))
+(defun mouse-event-proc-sub (bstate x1 y1)
+  (lambda ()
     ;; workaround for cursor position problem
     (let ((disp-x (mouse-get-disp-x (lem:window-view (lem:current-window)) x1 y1))
-          (cur-x  (mouse-get-cur-x  (lem:window-view (lem:current-window)) x1 y1))
-          (no-floating-window (if lem::*floating-windows* nil t)))
+          (cur-x  (mouse-get-cur-x  (lem:window-view (lem:current-window)) x1 y1)))
       ;; process mouse event
       (cond
-        ;; button1 down
-        ((and no-floating-window
+        ;; button-1 down
+        ((and (not lem::*floating-windows*)
               (logtest bstate (logior charms/ll:BUTTON1_PRESSED
                                       charms/ll:BUTTON1_CLICKED
                                       charms/ll:BUTTON1_DOUBLE_CLICKED
@@ -305,42 +321,49 @@
                    (setf *dragging-window* (list o 'y))
                    t)
                   ;; horizontal dragging window
-                  ((and press (= disp-x (- x 1)) (<= y y1 (+ y h -2)))
+                  ((and press (= disp-x (- x 1)) (<= y y1 (+ y h -1)))
                    (setf *dragging-window* (list o 'x))
                    t)
                   ;; move cursor
-                  ((and (<= x disp-x (+ x w -1)) (<= y y1 (+ y h -2)))
+                  ((and (<= x disp-x (+ x w -1)) (<= y y1 (+ y h -1)))
                    (setf (lem:current-window) o)
                    (mouse-move-to-cursor o (- disp-x x) (- y1 y))
                    (lem:redraw-display)
                    t)
                   (t nil))))
-            (lem:window-list))))
-        ;; button1 up
+            ;; include active minibuffer window
+            (if (lem::active-minibuffer-window)
+                (cons (lem::active-minibuffer-window) (lem:window-list))
+                (lem:window-list)))))
+        ;; button-1 up
         ((logtest bstate charms/ll:BUTTON1_RELEASED)
-         (let ((o (first *dragging-window*)))
+         (let ((o-orig (lem:current-window))
+               (o (first *dragging-window*)))
            (when (windowp o)
              (multiple-value-bind (x y w h) (mouse-get-window-rect o)
                (declare (ignore x y))
-               (setf (lem:current-window) o)
                (cond
                  ;; vertical dragging window
                  ((eq (second *dragging-window*) 'y)
                   (let ((vy (- (- (lem:window-y o) 1) y1)))
                     ;; this check is incomplete if 3 or more divisions exist
-                    (when (and no-floating-window
+                    (when (and (not lem::*floating-windows*)
                                (>= y1       *min-lines*)
                                (>= (+ h vy) *min-lines*))
+                      (setf (lem:current-window) o)
                       (lem:grow-window vy)
+                      (setf (lem:current-window) o-orig)
                       (lem:redraw-display))))
                  ;; horizontal dragging window
                  (t
                   (let ((vx (- (- (lem:window-x o) 1) cur-x)))
                     ;; this check is incomplete if 3 or more divisions exist
-                    (when (and no-floating-window
+                    (when (and (not lem::*floating-windows*)
                                (>= cur-x    *min-cols*)
                                (>= (+ w vx) *min-cols*))
+                      (setf (lem:current-window) o)
                       (lem:grow-window-horizontally vx)
+                      (setf (lem:current-window) o-orig)
                       (lem:redraw-display))))
                  )))
            (when o
@@ -372,7 +395,7 @@
       (escape-code (get-code "escape"))
       (ctrl-key nil)
       (alt-key  nil))
-  (defun get-ch ()
+  (defun get-charcode-from-input ()
     (let ((code          (getch-pad))
           (modifier-keys (charms/ll:PDC-get-key-modifiers)))
       (setf ctrl-key (logtest modifier-keys charms/ll:PDC_KEY_MODIFIER_CONTROL))
@@ -456,7 +479,7 @@
            )))
       code))
   (defun get-event (&optional esc-delaying)
-    (let ((code (get-ch)))
+    (let ((code (get-charcode-from-input)))
       (cond
         ((= code -1)
          ;; retry is necessary to exit lem normally

--- a/frontends/pdcurses/ncurses-pdcurseswin32.lisp
+++ b/frontends/pdcurses/ncurses-pdcurseswin32.lisp
@@ -354,7 +354,7 @@
                       (setf (lem:current-window) o-orig)
                       (lem:redraw-display))))
                  ;; horizontal dragging window
-                 (t
+                 ((eq (second *dragging-window*) 'x)
                   (let ((vx (- (- x 1) cur-x)))
                     ;; this check is incomplete if 3 or more divisions exist
                     (when (and (not lem::*floating-windows*)

--- a/lib/core/command.lisp
+++ b/lib/core/command.lisp
@@ -4,6 +4,7 @@
           exit-lem
           quick-exit
           keyboard-quit
+          nop-command
           self-insert-before-hook
           self-insert-after-hook
           self-insert
@@ -82,6 +83,9 @@
 (define-key *global-keymap* "C-g" 'keyboard-quit)
 (define-command keyboard-quit () ()
   (error 'editor-abort))
+
+(define-key *global-keymap* "NopKey" 'nop-command)
+(define-command nop-command () ())
 
 (define-editor-variable self-insert-before-hook '())
 (define-editor-variable self-insert-after-hook '())

--- a/lib/core/key.lisp
+++ b/lib/core/key.lisp
@@ -14,7 +14,7 @@
 
 (defparameter *named-key-syms*
   '("Backspace" "Delete" "Down" "End" "Escape" "F0" "F1" "F10" "F11" "F12" "F2" "F3" "F4" "F5" "F6" "F7" "F8" "F9"
-    "Home" "Left" "PageDown" "PageUp" "Return" "Right" "Space" "Tab" "Up"))
+    "Home" "Left" "NopKey" "PageDown" "PageUp" "Return" "Right" "Space" "Tab" "Up"))
 
 (defun named-key-sym-p (key-sym)
   (find key-sym *named-key-syms* :test #'string=))
@@ -149,6 +149,7 @@
 (setf (key-to-character (make-key :shift t :sym "PageDown")) (code-char 396))
 (setf (key-to-character (make-key :shift t :sym "PageUp")) (code-char 398))
 (setf (key-to-character (make-key :shift t :sym "Right")) (code-char 402))
+(setf (key-to-character (make-key :sym "NopKey")) (code-char 600)) ; used for nop-command
 
 (loop :for code :from #x21 :below #x7F
       :do (setf (key-to-character (make-key :sym (string (code-char code)))) (code-char code)))

--- a/lib/core/lem.lisp
+++ b/lib/core/lem.lisp
@@ -10,6 +10,9 @@
 (defvar *after-init-hook* '())
 (defvar *splash-function* nil)
 
+;; for mouse control
+(defparameter *terminal-io-saved* *terminal-io*)
+
 (defvar *in-the-editor* nil)
 
 (defvar *syntax-scan-window-recursive-p* nil)


### PR DESCRIPTION
マウスの制御をいろいろと改善しました。

1. isearch (C-s) と マウス操作 と C-g の組み合わせで、落ちる件の対応 (#470)

2. mouse-sgr1006 が有効にならないことがある件の対応
   ( `*terminal-io*` を lem の起動時に保存しておいて、
   そちらに エスケープシーケンス を出力するようにしました。
   また、エディタ終了時には OFF にするようにしました )

3. mouse-sgr1006 のマウスホイール対応
   (マウスホイールでスクロールするようにしました)

4. 補完メニューを出している間は、マウスクリックを無効化
   (変な状態になるため)

5. ミニバッファがアクティブのときは、
   マウスクリックでミニバッファにも移動可能とした

6. getch の一時的なタイムアウト設定をマクロ化
   (with-getch-input-timeout)

7. mouse-sgr1006 で、charms/ll: の使用を止めた
   (getch 関数を、引数で渡すようにしました)

mouse-sgr1006 の確認は、
Windows の VirtualBox 内の Linux Mint 19.3 (Cinnamon) で行いました。
(ターミナルは、GNOME Terminal 3.28.1 )

＜補足＞
mouse-sgr1006 を使う場合は、
M-x site-init-add-dependency で
mouse-sgr1006 の追加が必要です。
