### PR TITLE
Reduced the sensitivity of resize events

### DIFF
--- a/frontends/electron/lem-editor/lem-editor.js
+++ b/frontends/electron/lem-editor/lem-editor.js
@@ -136,9 +136,16 @@ class LemEditor extends HTMLElement {
         });
 
         const mainWindow = getCurrentWindow();
-        mainWindow.on('resize', () => {
+        let timeoutId = null;
+        const resizeHandler = () => {
             const { width, height } = mainWindow.getBounds();
             this.resize(width, height);
+        };
+        mainWindow.on('resize', () => {
+            if (timeoutId) {
+                clearTimeout(timeoutId);
+            }
+            timeoutId = setTimeout(resizeHandler, 200);
         });
 
         ipcRenderer.on('command', (event, message) => {


### PR DESCRIPTION
Electronフロントエンドにおいて、ウィンドウをリサイズした際に全てのイベントに対応しようとしてエディター画面のリサイズ追従が追いつかない現象がありました。
そのためイベントに対する感度を鈍くし、最後のリサイズイベントから200ms後に実際のリサイズを実行します。