### PR TITLE
Editor window will be resized in character size units

### DIFF
--- a/frontends/electron/index.html
+++ b/frontends/electron/index.html
@@ -9,7 +9,7 @@
     }
 
     canvas {
-        border-style: ridge ridge none ridge;
+        border-style: none;
     }
 </style>
 

--- a/frontends/electron/index.js
+++ b/frontends/electron/index.js
@@ -6,12 +6,19 @@ const menu = require('./menu');
 let mainWindow;
 
 electron.app.on('ready', function () {
-    mainWindow = new electron.BrowserWindow({});
+    mainWindow = new electron.BrowserWindow({
+        webPreferences: {
+            nodeIntegration: true
+        }
+    });
     mainWindow.setMenu(null);
     menu.setMenu(mainWindow);
     mainWindow.loadURL(`file://${__dirname}/index.html`);
     mainWindow.on('closed', function () {
         mainWindow = null;
+    });
+    mainWindow.on('will-resize', function(event) {
+        event.preventDefault();
     });
 
     electron.ipcMain.on('exit', function() {

--- a/frontends/electron/index.js
+++ b/frontends/electron/index.js
@@ -17,9 +17,15 @@ electron.app.on('ready', function () {
     mainWindow.on('closed', function () {
         mainWindow = null;
     });
-    mainWindow.on('will-resize', function(event) {
-        event.preventDefault();
-    });
+
+    // 'will-resize' event handling.
+    // Linux: Not supported
+    // MacOS: Does not work properly e.g. https://github.com/electron/electron/issues/21777
+    if (process.platform === 'win32') {
+        mainWindow.on('will-resize', function(event) {
+            event.preventDefault();
+        });
+    }
 
     electron.ipcMain.on('exit', function() {
         electron.app.quit();

--- a/frontends/electron/lem-editor/lem-editor.js
+++ b/frontends/electron/lem-editor/lem-editor.js
@@ -136,9 +136,16 @@ class LemEditor extends HTMLElement {
         });
 
         const mainWindow = getCurrentWindow();
-        mainWindow.on('resize', () => {
+        let timeoutId = null;
+        const resizeHandler = () => {
             const { width, height } = mainWindow.getBounds();
             this.resize(width, height);
+        };
+        mainWindow.on('resize', () => {
+            if (timeoutId) {
+                clearTimeout(timeoutId);
+            }
+            timeoutId = setTimeout(resizeHandler, 200);
         });
 
         ipcRenderer.on('command', (event, message) => {

--- a/frontends/electron/lem-editor/lem-editor.js
+++ b/frontends/electron/lem-editor/lem-editor.js
@@ -179,7 +179,7 @@ class LemEditor extends HTMLElement {
         this.picker = new Picker(this);
 
         // resize to initial size
-        this.resizeTo(option.initialCols, option.initialRows);
+        this.resizeTo(option.cols, option.rows);
     }
 
     resizeTo(col, row) {

--- a/frontends/electron/lem-editor/option.js
+++ b/frontends/electron/lem-editor/option.js
@@ -5,8 +5,8 @@ var option = {
     fontSize: 14,
     background: '#333',
     foreground: '#ccc',
-    initialCols: 80,
-    initialRows: 24
+    cols: 80,
+    rows: 24
 }
 
 exports.option = option;

--- a/frontends/electron/lem-editor/option.js
+++ b/frontends/electron/lem-editor/option.js
@@ -5,6 +5,8 @@ var option = {
     fontSize: 14,
     background: '#333',
     foreground: '#ccc',
+    initialCols: 80,
+    initialRows: 24
 }
 
 exports.option = option;

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "child_process": "^1.0.2",
-    "electron": "^1.7.9",
+    "electron": "^8.2.1",
     "keyboard-layout": "^2.0.13",
     "marked": "^0.3.6",
     "utf-8": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -19,5 +19,8 @@
   },
   "bin": {
     "lem-electron": "frontends/electron/cli.js"
+  },
+  "devDependencies": {
+    "electron-rebuild": "^1.10.1"
   }
 }


### PR DESCRIPTION
# 説明

- LemEditor.calcDisplayCols(), LemEditor.calcDisplayRows() において微調整を不要にしました
- 表示したい行・列数をもとにウインドウをリサイズできる LemEditor.resizeTo() を追加しました
- option.js に initialCols, initialRows を追加し、起動時にこの行列数で表示
- ウインドウを文字サイズ単位でリサイズできるようにします (今のところWindowsのみ)

# 制限
'will-resize'イベントを処理するため、Electronを更新しました。
ただしこのイベントの処理は今のところWindowsでしか正しく動作しないようです。

- Linux: 未サポート
- MacOS: イベントで渡されるnewBoundsの内容が正しくない場合がある
