### PR TITLE
Character unit resizing workaround for Linux and MacOS

### DIFF
--- a/frontends/electron/lem-editor/lem-editor.js
+++ b/frontends/electron/lem-editor/lem-editor.js
@@ -147,8 +147,8 @@ class LemEditor extends HTMLElement {
             const dh = height - cb.height;
             const ncw = this.fontWidth * Math.round((desiredBounds.width - dw) / this.fontWidth);
             const nch = this.fontHeight * Math.round((desiredBounds.height - dh) / this.fontHeight);
-            const nw = ncw + dw;
-            const nh = nch + dh;
+            const nw = Math.ceil(ncw + dw);
+            const nh = Math.ceil(nch + dh);
             const nx = desiredBounds.x === x ? x : x - (nw - width);
             const ny = desiredBounds.y === y ? y : y - (nh - height);
             return {


### PR DESCRIPTION
LinuxやMacOSでも文字サイズ単位でのリサイズになるよう回避策を実装してみました。

- will-resize イベントが使えないため、ユーザーがリサイズした後に再度文字サイズ単位でリサイズします
- 短時間に二重にリサイズするため環境によってちらつきが発生することがあります
- MacOSではElectronが対応すればこの回避策は不要になります (Windowsと同じ処理で良くなる)
