### PR TITLE
Enabled loading user option file

### DIFF
--- a/frontends/electron/electron.yml.example
+++ b/frontends/electron/electron.yml.example
@@ -1,0 +1,6 @@
+fontName: 'monospace'
+fontSize: 18
+background: '#333'
+foreground: '#ccc'
+cols: 100
+rows: 30

--- a/frontends/electron/lem-editor/lem-editor.js
+++ b/frontends/electron/lem-editor/lem-editor.js
@@ -6,7 +6,24 @@ const utf8 = require('utf-8')
 const ipcRenderer = require('electron').ipcRenderer;
 const getCurrentWindow = require('electron').remote.getCurrentWindow;
 const keyevent = require('./keyevent');
-const { option } = require('./option');
+
+// load option file
+const defaultOption = require('./option').option;
+const OPTION_FILE_NAME = 'electron.yml';
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+const homedir = process.env[process.platform === 'win32' ? 'USERPROFILE' : 'HOME'];
+const lemHome = process.env['LEM_HOME'] ||  path.join(homedir, '.lem');
+const optionFilePath = path.join(lemHome, OPTION_FILE_NAME);
+function loadOption(path) {
+	try {
+		return yaml.safeLoad(fs.readFileSync(path, 'utf-8'));
+	} catch (e) {
+		return {};
+	}
+}
+const option = Object.assign(defaultOption, loadOption(optionFilePath));
 
 class FontAttribute {
     constructor(name, size) {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "child_process": "^1.0.2",
     "electron": "^8.2.1",
+    "js-yaml": "^3.13.1",
     "marked": "^0.3.6",
     "native-keymap": "^2.1.2",
     "utf-8": "^1.0.0",


### PR DESCRIPTION
- Electronフロントエンドのオプションを .lem/electron.yml で設定可能にしました
- electron.ymlでの設定は frontends/electron/lem-editor/option.js の内容を上書きする動作です
- 設定ファイルを直接編集するためコメントアウトできるようYAMLフォーマットとしました
- 設定例を frontends/electron/electron.yml.example に追加しました