### PR TITLE
[vi-mode] Add x[it][!] support to ex-command

### DIFF
--- a/modes/vi-mode/ex-command.lisp
+++ b/modes/vi-mode/ex-command.lisp
@@ -61,6 +61,12 @@
   (ex-write range filename)
   (lem:exit-lem nil))
 
+(define-ex-command "^(x|xit)$" (range filename)
+  (ex-write-quit range filename nil))
+
+(define-ex-command "^(x|xit)!$" (range filename)
+  (ex-write-quit range filename t))
+
 (define-ex-command "^(sp|split)$" (range filename)
   (declare (ignore range))
   (lem:split-active-window-vertically)


### PR DESCRIPTION
This request adds the `:x` or `:xit` command to VI mode.
It does the same thing as `:wq` except it only writes
when changes have been made.

#### Why
Part of vi(m) and my go-to key to write and quit.

#### How to execute
Open a file, enable VI mode and execute `:x` 
Lem should write to the currently open file and quit. 