### PR TITLE
asm-mode: note that referenced documents when I was writing it

### DIFF
--- a/modes/asm-mode/asm-mode.lisp
+++ b/modes/asm-mode/asm-mode.lisp
@@ -5,6 +5,14 @@
   (:lock t))
 (in-package :lem-asm-mode)
 
+#|
+  I referenced softly these documents:
+
+  - [GNU as](https://sourceware.org/binutils/docs-2.34/as/index.html)
+  - [rgbasm: assembler for gameboy development](https://rednex.github.io/rgbds/rgbasm.5.html)
+
+|#
+
 (defun make-tmlanguage-asm ()
   (let ((patterns (make-tm-patterns
                    (make-tm-region "\"" "\"" :name 'syntax-string-attribute)


### PR DESCRIPTION
I referenced those when writing asm-mode:

- [GNU as](https://sourceware.org/binutils/docs-2.34/as/index.html)
- [rgbasm: assembler for gameboy development](https://rednex.github.io/rgbds/rgbasm.5.html)