### PR TITLE
fm-mode: resize current frame after switching

### DIFF
--- a/modes/fm-mode/fm-mode.lisp
+++ b/modes/fm-mode/fm-mode.lisp
@@ -260,6 +260,7 @@
         (when %frame
           (setf (vf-current vf) %frame)
           (lem:map-frame (implementation) (%frame-frame %frame))))
+      (lem::change-display-size-hook)
       (setf (vf-changed vf) t))))
 
 (define-key *global-keymap* "C-z n" 'fm-next)
@@ -277,4 +278,5 @@
         (when %frame
           (setf (vf-current vf) %frame)
           (lem:map-frame (implementation) (%frame-frame %frame))))
+      (lem::change-display-size-hook)
       (setf (vf-changed vf) t))))


### PR DESCRIPTION
fm-modeを使用中に画面をリサイズしてフレームを切り替えると`(current-frame)`じゃないフレームはリサイズ時の処理が走らないので表示がおかしなるバグを修正しました。

This PR fixes a bug that breaks rendering result of frames that not `(current-frame)` after resizing window manually in fm-mode.