### PR TITLE
Remove nonexistent global variables

### DIFF
--- a/contrib/fbar/fbar.lisp
+++ b/contrib/fbar/fbar.lisp
@@ -117,7 +117,7 @@
 	     0 0 *fbar-width*
 	     (1- (display-height))  nil))
       
-      (setf lem::*current-window* *fbar-window*)
+      (setf (current-window) *fbar-window*)
       (setf (current-buffer) *fbar-buffer*)
       (redraw-display)))
 

--- a/contrib/mouse-sgr1006/main.lisp
+++ b/contrib/mouse-sgr1006/main.lisp
@@ -48,7 +48,7 @@
         (decf x1)
         (decf y1)
         ;; check mouse status
-        (when (or (and (not lem::*floating-windows*)
+        (when (or (and (not (lem:frame-floating-windows (lem:current-frame)))
                        (eql btype *mouse-button-1*)
                        (or (eql bstate #\m)
                            (eql bstate #\M)))
@@ -65,7 +65,7 @@
     ;; process mouse event
     (cond
       ;; button-1 down
-      ((and (not lem::*floating-windows*)
+      ((and (not (lem:frame-floating-windows (lem:current-frame)))
             (eql btype *mouse-button-1*)
             (eql bstate #\M))
        (find-if
@@ -103,7 +103,7 @@
                ((eq (second *dragging-window*) 'y)
                 (let ((vy (- (- y 1) y1)))
                   ;; this check is incomplete if 3 or more divisions exist
-                  (when (and (not lem::*floating-windows*)
+                  (when (and (not (lem:frame-floating-windows (lem:current-frame)))
                              (>= y1       *min-lines*)
                              (>= (+ h vy) *min-lines*))
                     (setf (lem:current-window) o)
@@ -114,7 +114,7 @@
                ((eq (second *dragging-window*) 'x)
                 (let ((vx (- (- x 1) x1)))
                   ;; this check is incomplete if 3 or more divisions exist
-                  (when (and (not lem::*floating-windows*)
+                  (when (and (not (lem:frame-floating-windows (lem:current-frame)))
                              (>= x1       *min-cols*)
                              (>= (+ w vx) *min-cols*))
                     (setf (lem:current-window) o)

--- a/frontends/pdcurses/ncurses-pdcurseswin32.lisp
+++ b/frontends/pdcurses/ncurses-pdcurseswin32.lisp
@@ -286,7 +286,7 @@
 (defun mouse-event-proc (bstate x1 y1)
   (lambda ()
     ;; check mouse status
-    (when (or (and (not lem::*floating-windows*)
+    (when (or (and (not (lem:frame-floating-windows (lem:current-frame)))
                    (logtest bstate (logior charms/ll:BUTTON1_PRESSED
                                            charms/ll:BUTTON1_CLICKED
                                            charms/ll:BUTTON1_DOUBLE_CLICKED
@@ -306,7 +306,7 @@
       ;; process mouse event
       (cond
         ;; button-1 down
-        ((and (not lem::*floating-windows*)
+        ((and (not (lem:frame-floating-windows (lem:current-frame)))
               (logtest bstate (logior charms/ll:BUTTON1_PRESSED
                                       charms/ll:BUTTON1_CLICKED
                                       charms/ll:BUTTON1_DOUBLE_CLICKED
@@ -346,7 +346,7 @@
                  ((eq (second *dragging-window*) 'y)
                   (let ((vy (- (- y 1) y1)))
                     ;; this check is incomplete if 3 or more divisions exist
-                    (when (and (not lem::*floating-windows*)
+                    (when (and (not (lem:frame-floating-windows (lem:current-frame)))
                                (>= y1       *min-lines*)
                                (>= (+ h vy) *min-lines*))
                       (setf (lem:current-window) o)
@@ -357,7 +357,7 @@
                  ((eq (second *dragging-window*) 'x)
                   (let ((vx (- (- x 1) cur-x)))
                     ;; this check is incomplete if 3 or more divisions exist
-                    (when (and (not lem::*floating-windows*)
+                    (when (and (not (lem:frame-floating-windows (lem:current-frame)))
                                (>= cur-x    *min-cols*)
                                (>= (+ w vx) *min-cols*))
                       (setf (lem:current-window) o)

--- a/lib/core/window.lisp
+++ b/lib/core/window.lisp
@@ -485,7 +485,7 @@
                (when (< (point-charpos point) i)
                  (decf n1)
                  (when (<= n1 0)
-                   ;; cursor-x offset is recovered by *next-line-prev-column*
+                   ;; cursor-x offset is recovered by (get-next-line-context-column)
                    (line-offset point 0 i)
                    (return-from move-to-next-virtual-line-n point)))))
             ;; go to next line


### PR DESCRIPTION
#500 等で削除されたグローバル変数等が、一部ソースに残っていたため削除しました。

確認済み項目：
```
lib/core/minibuffer.lisp
  *minibuf-window*             なし
  *minibuffer-calls-window*    なし
  *minibuffer-start-charpos*   なし
  *echoarea-buffer*            なし
  *minibuffer-buffer*          なし

lib/core/window.lisp
  redraw-display*              なし
  *floating-windows*           8個削除
  *header-windows*             なし
  *modified-floating-windows*  なし
  *window-tree*                なし
  *current-window*             1個削除
  *modify-header-windows*      なし

lib/core/command.lisp
  *next-line-prev-column*      1個削除
```
