### PR TITLE
Fix mouse control on curses frontend v2

### DIFF
--- a/contrib/mouse-sgr1006/main.lisp
+++ b/contrib/mouse-sgr1006/main.lisp
@@ -48,7 +48,7 @@
         (decf x1)
         (decf y1)
         ;; check mouse status
-        (when (or (and (not (lem:frame-floating-windows (lem:current-frame)))
+        (when (or (and (not (lem:floating-window-p (lem:current-window)))
                        (eql btype *mouse-button-1*)
                        (or (eql bstate #\m)
                            (eql bstate #\M)))
@@ -65,11 +65,11 @@
     ;; process mouse event
     (cond
       ;; button-1 down
-      ((and (not (lem:frame-floating-windows (lem:current-frame)))
+      ((and (not (lem:floating-window-p (lem:current-window)))
             (eql btype *mouse-button-1*)
             (eql bstate #\M))
        (find-if
-        (lambda(o)
+        (lambda (o)
           (multiple-value-bind (x y w h) (get-window-rect o)
             (cond
               ;; vertical dragging window
@@ -103,7 +103,7 @@
                ((eq (second *dragging-window*) 'y)
                 (let ((vy (- (- y 1) y1)))
                   ;; this check is incomplete if 3 or more divisions exist
-                  (when (and (not (lem:frame-floating-windows (lem:current-frame)))
+                  (when (and (not (lem:floating-window-p (lem:current-window)))
                              (>= y1       *min-lines*)
                              (>= (+ h vy) *min-lines*))
                     (setf (lem:current-window) o)
@@ -114,7 +114,7 @@
                ((eq (second *dragging-window*) 'x)
                 (let ((vx (- (- x 1) x1)))
                   ;; this check is incomplete if 3 or more divisions exist
-                  (when (and (not (lem:frame-floating-windows (lem:current-frame)))
+                  (when (and (not (lem:floating-window-p (lem:current-window)))
                              (>= x1       *min-cols*)
                              (>= (+ w vx) *min-cols*))
                     (setf (lem:current-window) o)

--- a/frontends/pdcurses/ncurses-pdcurseswin32.lisp
+++ b/frontends/pdcurses/ncurses-pdcurseswin32.lisp
@@ -286,7 +286,7 @@
 (defun mouse-event-proc (bstate x1 y1)
   (lambda ()
     ;; check mouse status
-    (when (or (and (not (lem:frame-floating-windows (lem:current-frame)))
+    (when (or (and (not (lem:floating-window-p (lem:current-window)))
                    (logtest bstate (logior charms/ll:BUTTON1_PRESSED
                                            charms/ll:BUTTON1_CLICKED
                                            charms/ll:BUTTON1_DOUBLE_CLICKED
@@ -306,14 +306,14 @@
       ;; process mouse event
       (cond
         ;; button-1 down
-        ((and (not (lem:frame-floating-windows (lem:current-frame)))
+        ((and (not (lem:floating-window-p (lem:current-window)))
               (logtest bstate (logior charms/ll:BUTTON1_PRESSED
                                       charms/ll:BUTTON1_CLICKED
                                       charms/ll:BUTTON1_DOUBLE_CLICKED
                                       charms/ll:BUTTON1_TRIPLE_CLICKED)))
          (let ((press (logtest bstate charms/ll:BUTTON1_PRESSED)))
            (find-if
-            (lambda(o)
+            (lambda (o)
               (multiple-value-bind (x y w h) (mouse-get-window-rect o)
                 (cond
                   ;; vertical dragging window
@@ -346,7 +346,7 @@
                  ((eq (second *dragging-window*) 'y)
                   (let ((vy (- (- y 1) y1)))
                     ;; this check is incomplete if 3 or more divisions exist
-                    (when (and (not (lem:frame-floating-windows (lem:current-frame)))
+                    (when (and (not (lem:floating-window-p (lem:current-window)))
                                (>= y1       *min-lines*)
                                (>= (+ h vy) *min-lines*))
                       (setf (lem:current-window) o)
@@ -357,7 +357,7 @@
                  ((eq (second *dragging-window*) 'x)
                   (let ((vx (- (- x 1) cur-x)))
                     ;; this check is incomplete if 3 or more divisions exist
-                    (when (and (not (lem:frame-floating-windows (lem:current-frame)))
+                    (when (and (not (lem:floating-window-p (lem:current-window)))
                                (>= cur-x    *min-cols*)
                                (>= (+ w vx) *min-cols*))
                       (setf (lem:current-window) o)


### PR DESCRIPTION
- マウス操作が出来なくなった件の修正になります (関連プルリクエスト #515)。

- ガードの条件を「current-window が floating-window かどうか」だけにしました。

- find-file のファイル名補完の popup-window や、
  割り込み表示の typeout-window については、
  これでガードできるようでした。

- ただ、言語のキーワード補完の popup-window のように、
  この条件にヒットしないケースもあるようでした。
  あまり条件を複雑にしたくなかったので、そこは妥協しました。
  (マウスクリックすると、言語のキーワード補完の選択表示は消えます)
