### PR TITLE
Now if color attribute does not specify foreground or background color, the default color is used explicitly

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,15 @@
 # ChangeLog
 
+## Not released
+
+### Fixed
+
+* Now if color attribute does not specify foreground or background color,
+  the default color is used explicitly.
+  
+  This fixes colour glitches in case if colour theme sets the background
+  and foreground colours and Lem's frontend is NCurses.
+
 ## [v1.8]
 
 (processed upto a4bea761)

--- a/frontends/ncurses/term.lisp
+++ b/frontends/ncurses/term.lisp
@@ -373,13 +373,19 @@
         (charms/ll:color-pair *pair-counter*)))
 
 (defun get-color-pair (fg-color-name bg-color-name)
-  (let* ((fg-color (if (null fg-color-name) -1 (get-color fg-color-name)))
-         (bg-color (if (null bg-color-name) -1 (get-color bg-color-name)))
-         (pair-color (cons fg-color bg-color)))
-    (cond ((gethash pair-color *color-pair-table*))
-          ((< *pair-counter* *color-pairs*)
-           (init-pair pair-color))
-          (t 0))))
+  (multiple-value-bind (default-fg default-bg)
+      (get-default-colors)
+    (let* ((fg-color (if (null fg-color-name)
+                         default-fg
+                         (get-color fg-color-name)))
+           (bg-color (if (null bg-color-name)
+                         default-bg
+                         (get-color bg-color-name)))
+           (pair-color (cons fg-color bg-color)))
+      (cond ((gethash pair-color *color-pair-table*))
+            ((< *pair-counter* *color-pairs*)
+             (init-pair pair-color))
+            (t 0)))))
 
 #+(or)
 (defun get-color-content (n)


### PR DESCRIPTION
This pull fixes colour glitches in case if colour theme sets the background and foreground colours and Lem's frontend is NCurses.

Two pictures to illustrate.

Before this patch:

<img width="478" alt="Screenshot 2020-09-06 at 22 54 58" src="https://user-images.githubusercontent.com/24827/92334181-54fe4f00-f094-11ea-9e3c-73d0688ab352.png">

After this patch:

<img width="526" alt="Screenshot 2020-09-06 at 22 51 16" src="https://user-images.githubusercontent.com/24827/92334183-5cbdf380-f094-11ea-83fb-93b3c6d0dfed.png">
