### PR TITLE
Fix popup window position

### DIFF
--- a/lib/core/popup-window.lisp
+++ b/lib/core/popup-window.lisp
@@ -27,7 +27,13 @@
   (t :background "#444" :foreground "white"))
 
 (defun compute-cursor-position (source-window width height)
-  (let* ((x (+ (window-x source-window)
+  (let* ((b2 (* +border-size+ 2))
+         ;; -2 is workaround for windows pdcurses
+         (disp-w (max (- (display-width)  b2 #+win32 2)
+                      +min-width+))
+         (disp-h (max (- (display-height) b2)
+                      +min-height+))
+         (x (+ (window-x source-window)
                (window-cursor-x source-window)))
          (y (+ (window-y source-window)
                (window-cursor-y source-window)
@@ -36,13 +42,7 @@
          (w  (max (+ width #+win32 1)
                   +min-width+))
          (h  (max height
-                  +min-height+))
-         (b2 (* +border-size+ 2))
-         ;; -2 is workaround for windows pdcurses
-         (disp-w (max (- (display-width)  b2 #+win32 2)
-                      +min-width+))
-         (disp-h (max (- (display-height) b2)
-                      +min-height+)))
+                  +min-height+)))
     ;; calc y and h
     (when (> (+ y height) disp-h)
       (decf h (- (+ y height) disp-h)))
@@ -64,29 +64,31 @@
     (values x y w h)))
 
 (defun compute-topright-position (source-window width height)
-  (let* ((x  (window-x source-window))
-         (y  1)
+  (let* ((b2 (* +border-size+ 2))
+         (win-x (window-x source-window))
+         (win-y (window-y source-window))
+         (win-w (max (- (window-width source-window)  b2 2)
+                     +min-width+))
+         (win-h (max (- (window-height source-window) b2)
+                     +min-height+))
+         (x  win-x)
+         (y  (+ win-y 1))
          ;; +1 is workaround for windows pdcurses
          (w  (max (+ width #+win32 1)
                   +min-width+))
          (h  (max height
-                  +min-height+))
-         (b2 (* +border-size+ 2))
-         (disp-w (max (- (display-width)  b2 2)
-                      +min-width+))
-         (disp-h (max (- (display-height) b2)
-                      +min-height+)))
+                  +min-height+)))
     ;; calc y and h
-    (when (> (+ y height) disp-h)
-      (decf h (- (+ y height) disp-h)))
-    (when (<= h 0) ; for safety
-      (setf y 0)
-      (setf h (min height disp-h)))
+    (when (> (+ y height) (+ win-y win-h))
+      (decf h (- (+ y height) (+ win-y win-h))))
+    (when (<= h 0)    ; for safety
+      (setf y win-y)
+      (setf h (min height win-h)))
     ;; calc x and w
-    (incf x (- disp-w w))
-    (when (< x 0)  ; for safety
-      (setf x 0)
-      (setf w (min width disp-w)))
+    (incf x (- win-w w))
+    (when (< x win-x) ; for safety
+      (setf x win-x)
+      (setf w (min width win-w)))
     (values x y w h)))
 
 (defun compute-popup-window-position (source-window width height &optional (gravity :cursor))

--- a/lib/core/popup-window.lisp
+++ b/lib/core/popup-window.lisp
@@ -8,6 +8,10 @@
 (defparameter +min-width+   3)
 (defparameter +min-height+  1)
 
+;; for windows pdcurses
+(defvar *extra-right-margin* 0)
+(defvar *extra-width-margin* 0)
+
 (defvar *menu-buffer* nil)
 (defvar *menu-window* nil)
 (defvar *focus-overlay* nil)
@@ -28,8 +32,7 @@
 
 (defun compute-cursor-position (source-window width height)
   (let* ((b2 (* +border-size+ 2))
-         ;; -2 is workaround for windows pdcurses
-         (disp-w (max (- (display-width)  b2 #+win32 2)
+         (disp-w (max (- (display-width)  b2 *extra-right-margin*)
                       +min-width+))
          (disp-h (max (- (display-height) b2)
                       +min-height+))
@@ -38,11 +41,10 @@
          (y (+ (window-y source-window)
                (window-cursor-y source-window)
                1))
-         ;; +1 is workaround for windows pdcurses
-         (w  (max (+ width #+win32 1)
-                  +min-width+))
-         (h  (max height
-                  +min-height+)))
+         (w (max (+ width *extra-width-margin*)
+                 +min-width+))
+         (h (max height
+                 +min-height+)))
     ;; calc y and h
     (when (> (+ y height) disp-h)
       (decf h (- (+ y height) disp-h)))
@@ -73,8 +75,7 @@
                      +min-height+))
          (x  win-x)
          (y  (+ win-y 1))
-         ;; +1 is workaround for windows pdcurses
-         (w  (max (+ width #+win32 1)
+         (w  (max (+ width *extra-width-margin*)
                   +min-width+))
          (h  (max height
                   +min-height+)))

--- a/lib/core/popup-window.lisp
+++ b/lib/core/popup-window.lisp
@@ -67,7 +67,7 @@
   (let* ((b2 (* +border-size+ 2))
          (win-x (window-x source-window))
          (win-y (window-y source-window))
-         (win-w (max (- (window-width source-window)  b2 2)
+         (win-w (max (- (window-width  source-window) b2 2)
                      +min-width+))
          (win-h (max (- (window-height source-window) b2)
                      +min-height+))

--- a/lib/core/popup-window.lisp
+++ b/lib/core/popup-window.lisp
@@ -5,6 +5,8 @@
 (in-package :lem.popup-window)
 
 (defparameter +border-size+ 1)
+(defparameter +min-width+   3)
+(defparameter +min-height+  1)
 
 (defvar *menu-buffer* nil)
 (defvar *menu-window* nil)
@@ -25,43 +27,67 @@
   (t :background "#444" :foreground "white"))
 
 (defun compute-cursor-position (source-window width height)
-  (let* ((y (+ (window-y source-window)
+  (let* ((x (+ (window-x source-window)
+               (window-cursor-x source-window)))
+         (y (+ (window-y source-window)
                (window-cursor-y source-window)
                1))
-         (x (+ (window-x source-window)
-               (let ((x (point-column (lem::window-buffer-point source-window))))
-                 (when (<= (window-width source-window) x)
-                   (let ((mod (mod x (window-width source-window)))
-                         (floor (floor x (window-width source-window))))
-                     (setf x (+ mod floor))
-                     (incf y floor)))
-                 x))))
-    (cond
-      ((<= (display-height)
-           (+ y (min height
-                     (floor (display-height) 3))))
-       (cond ((>= 0 (- y height))
-              (setf y 1)
-              (setf height (min height (- (display-height) 1))))
-             (t
-              (decf y (+ height 1)))))
-      ((<= (display-height) (+ y height))
-       (setf height (- (display-height) y))))
-    (when (<= (display-width) (+ x width))
-      (when (< (display-width) width)
-        (setf width (display-width)))
-      (setf x (- (display-width) width)))
-    (values x y width height)))
+         ;; +1 is workaround for windows pdcurses
+         (w  (max (+ width #+win32 1)
+                  +min-width+))
+         (h  (max height
+                  +min-height+))
+         (b2 (* +border-size+ 2))
+         ;; -2 is workaround for windows pdcurses
+         (disp-w (max (- (display-width)  b2 #+win32 2)
+                      +min-width+))
+         (disp-h (max (- (display-height) b2)
+                      +min-height+)))
+    ;; calc y and h
+    (when (> (+ y height) disp-h)
+      (decf h (- (+ y height) disp-h)))
+    (when (< h (min height (floor disp-h 3)))
+      (setf h height)
+      (decf y (+ height b2 1)))
+    (when (< y 0)
+      (decf h (- y))
+      (setf y 0))
+    (when (<= h 0) ; for safety
+      (setf y 0)
+      (setf h (min height disp-h)))
+    ;; calc x and w
+    (when (> (+ x width) disp-w)
+      (decf x (- (+ x width) disp-w)))
+    (when (< x 0)  ; for safety
+      (setf x 0)
+      (setf w (min width disp-w)))
+    (values x y w h)))
 
 (defun compute-topright-position (source-window width height)
-  (let ((x (+ (window-x source-window)
-              (alexandria:clamp (- (window-width source-window) width 4)
-                                0
-                                (window-width source-window))))
-        (y 1))
-    (when (< (window-width source-window) width)
-      (setf width (- (window-width source-window) 4)))
-    (values x y width height)))
+  (let* ((x  (window-x source-window))
+         (y  1)
+         ;; +1 is workaround for windows pdcurses
+         (w  (max (+ width #+win32 1)
+                  +min-width+))
+         (h  (max height
+                  +min-height+))
+         (b2 (* +border-size+ 2))
+         (disp-w (max (- (display-width)  b2 2)
+                      +min-width+))
+         (disp-h (max (- (display-height) b2)
+                      +min-height+)))
+    ;; calc y and h
+    (when (> (+ y height) disp-h)
+      (decf h (- (+ y height) disp-h)))
+    (when (<= h 0) ; for safety
+      (setf y 0)
+      (setf h (min height disp-h)))
+    ;; calc x and w
+    (incf x (- disp-w w))
+    (when (< x 0)  ; for safety
+      (setf x 0)
+      (setf w (min width disp-w)))
+    (values x y w h)))
 
 (defun compute-popup-window-position (source-window width height &optional (gravity :cursor))
   (ecase gravity
@@ -75,7 +101,9 @@
       (compute-popup-window-position source-window width height gravity)
     (cond (destination-window
            (lem::window-set-size destination-window width height)
-           (lem::window-set-pos destination-window x y)
+           (lem::window-set-pos destination-window
+                                (+ x +border-size+)
+                                (+ y +border-size+))
            destination-window)
           (t
            (make-instance 'popup-window
@@ -192,10 +220,10 @@
       (create-menu-buffer items *print-spec*)
     (update-focus-overlay (buffer-point buffer))
     (popup-window (current-window)
-                   buffer
-                   width
-                   (min 20 (length items))
-                   :destination-window *menu-window*)))
+                  buffer
+                  width
+                  (min 20 (length items))
+                  :destination-window *menu-window*)))
 
 (defmethod lem-if:popup-menu-quit (implementation)
   (when *focus-overlay*

--- a/lib/core/prompt-window.lisp
+++ b/lib/core/prompt-window.lisp
@@ -51,7 +51,8 @@
 (define-major-mode prompt-mode nil
     (:name "prompt"
      :keymap *prompt-mode-keymap*)
-  (setf (lem::switchable-buffer-p (current-buffer)) t))
+  (setf (lem::switchable-buffer-p (current-buffer)) t)
+  (setf (variable-value 'truncate-lines :buffer (current-buffer)) nil))
 
 (define-attribute prompt-attribute
   (:light :foreground "gray27" :bold-p t)

--- a/lib/core/window.lisp
+++ b/lib/core/window.lisp
@@ -367,12 +367,14 @@ next line because it is at the end of width."
   (let ((point (window-buffer-point window)))
     (multiple-value-bind (x next)
         (%calc-window-cursor-x point window)
+      (declare (ignore next))
       x)))
 
 (defun cursor-goto-next-line-p (point window)
   "Check if the cursor goes to next line because it is at the end of width."
   (multiple-value-bind (x next)
       (%calc-window-cursor-x point window)
+    (declare (ignore x))
     next))
 
 (defun map-wrapping-line (window string fn)

--- a/lib/core/window.lisp
+++ b/lib/core/window.lisp
@@ -364,11 +364,10 @@ next line because it is at the end of width."
         (values cur-x nil))))
 
 (defun window-cursor-x (window)
-  (let ((point (window-buffer-point window)))
-    (multiple-value-bind (x next)
-        (%calc-window-cursor-x point window)
-      (declare (ignore next))
-      x)))
+  (multiple-value-bind (x next)
+      (%calc-window-cursor-x (window-buffer-point window) window)
+    (declare (ignore next))
+    x))
 
 (defun cursor-goto-next-line-p (point window)
   "Check if the cursor goes to next line because it is at the end of width."


### PR DESCRIPTION
ポップアップ画面の表示位置を修正しました。
(画面の端で表示させると、はみ出してスクロールしてしまったり (PDCursesだけかも)、
補完の候補をしぼりこむときに、上にずれて表示される 等)
