### PR TITLE
[lem-pdcurses] Try to fix Japanese character display on Windows 10

### DIFF
--- a/frontends/ncurses/cl-charms-pdcurseswin32.lisp
+++ b/frontends/ncurses/cl-charms-pdcurseswin32.lisp
@@ -2,7 +2,13 @@
 
 (in-package :cl-charms/low-level)
 
-(export '(getch color-pair resizeterm *escdelay*))
+(export '(getch
+          color-pair
+          resizeterm
+          *escdelay*
+          *pdcurses-version-number*
+          *pdcurses-version-info*
+          PDC-save-key-modifiers))
 
 ;; add missing definitions
 (defun getch () (wgetch *stdscr*))
@@ -11,14 +17,57 @@
 (defvar *escdelay-dummy* 0)
 (define-symbol-macro *escdelay* *escdelay-dummy*)
 
+;; pdcurses version number
+;;  (this is floating-point number (e.g. 3.9))
+(defvar *pdcurses-version-number*
+  (read-from-string (charms/ll::curses-version) t nil :start 9))
+
+;; pdcurses version information
+(cffi:defcstruct pdcversioninfo
+  (flags :short)
+  (build :short)
+  (major :unsigned-char)
+  (minor :unsigned-char)
+  (csize :unsigned-char)
+  (bsize :unsigned-char))
+;(define-exported-cfuns ("PDC_get_version") :void (ver-info :pointer))
+(defun PDC-get-version (ver-info)
+  ;; PDC_get_version has been added in pdcurses version 3.8
+  ;(if (cffi:foreign-symbol-pointer "PDC_get_version")
+  (if (>= *pdcurses-version-number* 3.8)
+      (cffi:foreign-funcall "PDC_get_version" :pointer ver-info :void)
+      (progn
+        (setf (cffi:foreign-slot-value ver-info '(:struct pdcversioninfo) 'flags) 0)
+        (setf (cffi:foreign-slot-value ver-info '(:struct pdcversioninfo) 'build) 0)
+        (setf (cffi:foreign-slot-value ver-info '(:struct pdcversioninfo) 'major) 0)
+        (setf (cffi:foreign-slot-value ver-info '(:struct pdcversioninfo) 'minor) 0)
+        (setf (cffi:foreign-slot-value ver-info '(:struct pdcversioninfo) 'csize) 0)
+        (setf (cffi:foreign-slot-value ver-info '(:struct pdcversioninfo) 'bsize) 0)
+        nil)))
+(defvar *pdcurses-version-info*
+  (cffi:with-foreign-object (ver-info '(:struct pdcversioninfo))
+    (PDC-get-version ver-info)
+    (list (cffi:foreign-slot-value ver-info '(:struct pdcversioninfo) 'flags)
+          (cffi:foreign-slot-value ver-info '(:struct pdcversioninfo) 'build)
+          (cffi:foreign-slot-value ver-info '(:struct pdcversioninfo) 'major)
+          (cffi:foreign-slot-value ver-info '(:struct pdcversioninfo) 'minor)
+          (cffi:foreign-slot-value ver-info '(:struct pdcversioninfo) 'csize)
+          (cffi:foreign-slot-value ver-info '(:struct pdcversioninfo) 'bsize))))
+
 ;; enable modifier keys
 (define-exported-constant PDC_KEY_MODIFIER_SHIFT   1)
 (define-exported-constant PDC_KEY_MODIFIER_CONTROL 2)
 (define-exported-constant PDC_KEY_MODIFIER_ALT     4)
 (define-exported-constant PDC_KEY_MODIFIER_NUMLOCK 8)
 (define-exported-cfuns ("PDC_get_key_modifiers") :unsigned-long)
-(define-exported-cfuns ("PDC_save_key_modifiers") :int (flag bool))
 (define-exported-cfuns ("PDC_return_key_modifiers") :int (flag bool))
+;(define-exported-cfuns ("PDC_save_key_modifiers") :int (flag bool))
+(defun PDC-save-key-modifiers (flag)
+  ;; PDC_save_key_modifiers has been removed in pdcurses version 3.9
+  ;(if (cffi:foreign-symbol-pointer "PDC_save_key_modifiers")
+  (if (< *pdcurses-version-number* 3.9)
+      (cffi:foreign-funcall "PDC_save_key_modifiers" bool flag :int)
+      0))
 
 ;; for extracting a character code
 (define-exported-constant A_CHARTEXT #x0000ffff)

--- a/frontends/ncurses/term.lisp
+++ b/frontends/ncurses/term.lisp
@@ -49,6 +49,10 @@
   (setf (aref *colors* index) (list r g b index)))
 
 (defun init-colors (n)
+
+  ;; limit max colors
+  (if (> n 256) (setf n 256))
+
   (let ((counter 0))
     (flet ((add-color (r g b)
              (term-set-color counter r g b (<= 8 counter))


### PR DESCRIPTION
- 最近、Windows 10 の PC を入手したのですが、
  Windows Console API の動作が変わってしまったようで、
  日本語の表示がうまくできなくなっていました。
  (Windows Terminal が出来たことで、conhost v2 というものになったようです)

- 大きなところとしては、
  SetConsoleCursorPosition() が、Windows 10 では、
  文字数ではなく文字幅単位 (全角文字を 2 と数える) で、
  X座標を指定するように変わっていました。
  (Windows 8.1 までは、( chcp 65001 の場合は) 文字数で指定するようになっていました。
  (これは、日本語版 Windows の固有の動作だったのかもしれない。。。))

- それで、ちょっと Lem だけでは修正できなかったため、
  PDCurses の改造版を作成してみました。
  https://github.com/Hamayama/PDCurses-win10-jp

- 本プルリクエストは、その改造版が入っていた場合に、
  処理を分岐して、Windows 10 で日本語の表示ができるようにするものです。
  (PDCurses の改造版が見つからなければ、今まで通りの処理になります)
