### PR TITLE
Set encoding of config.lisp

### DIFF
--- a/lib/core/config.lisp
+++ b/lib/core/config.lisp
@@ -30,7 +30,6 @@
     (with-open-file (out (ensure-config-pathname)
                          :direction :output
                          :if-exists :supersede
-                         :if-does-not-exist :create
-                         :external-format uiop:*utf-8-external-format*)
+                         :if-does-not-exist :create)
       (pprint plist out)))
   value)

--- a/lib/core/config.lisp
+++ b/lib/core/config.lisp
@@ -30,6 +30,7 @@
     (with-open-file (out (ensure-config-pathname)
                          :direction :output
                          :if-exists :supersede
-                         :if-does-not-exist :create)
+                         :if-does-not-exist :create
+                         :external-format uiop:*utf-8-external-format*)
       (pprint plist out)))
   value)

--- a/lib/core/lem.lisp
+++ b/lib/core/lem.lisp
@@ -203,6 +203,12 @@
    :name "editor"))
 
 (defun lem (&rest args)
+
+  ;; for sbcl, set the default file encoding to utf-8
+  ;; (on windows, the default is determined by code page (e.g. :cp932))
+  #+sbcl
+  (setf sb-impl::*default-external-format* :utf-8)
+
   (setf args (parse-args args))
 
   (cond
@@ -217,7 +223,7 @@
     (t (log:config :off)))
 
   (log:info "Starting Lem")
-  
+
   (if *in-the-editor*
       (apply-args args)
       (invoke-frontend


### PR DESCRIPTION
Windows 上で、isearch で日本語を検索すると、
config.lisp の読み込みエラーになったため、
エンコーディングを指定するようにしました。

( uiop:read-file-form のソースを調べて、
同じものを with-open-file の :external-format にセットしました)
