### PR TITLE
[scheme-mode] Fix autodoc display

### DIFF
--- a/modes/scheme-mode/scheme-mode.lisp
+++ b/modes/scheme-mode/scheme-mode.lisp
@@ -33,6 +33,8 @@
 (define-key *scheme-mode-keymap* "C-c C-c" 'scheme-compile-define)
 (define-key *scheme-mode-keymap* "C-c Return" 'scheme-macroexpand)
 (define-key *scheme-mode-keymap* "C-c M-m" 'scheme-macroexpand-all)
+;(define-key *scheme-mode-keymap* "Space" 'scheme-insert-space-and-autodoc)
+;(define-key *scheme-mode-keymap* "C-c C-d C-a" 'scheme-autodoc)
 (define-key *scheme-mode-keymap* "C-c C-d C-a" 'scheme-autodoc-with-typeout)
 (define-key *scheme-mode-keymap* "C-c C-d d" 'scheme-describe-symbol)
 (define-key *scheme-mode-keymap* "C-c C-z" 'scheme-switch-to-repl-buffer)
@@ -71,8 +73,9 @@
 ;;    :repl : use 'scheme-set-library' command for only repl
 ;;    nil   : disable 'scheme-set-library' command
 ;;  *use-scheme-autodoc*
-;;    t     : display function information in minibuffer
-;;    nil   : don't display function information in minibuffer
+;;    t         : display function information in popup window at cursor
+;;    :topright : display function information in popup window at top right corner
+;;    nil       : don't display function information
 (defvar *use-scheme-slime* :auto)
 (defvar *use-scheme-set-library* :repl)
 (defvar *use-scheme-autodoc* t)

--- a/modes/scheme-mode/swank-connection.lisp
+++ b/modes/scheme-mode/swank-connection.lisp
@@ -398,8 +398,9 @@
   (check-connection)
   (autodoc (lambda (temp-buffer)
              (let ((buffer (make-buffer (buffer-name temp-buffer))))
-               (erase-buffer buffer)
-               (insert-buffer (buffer-point buffer) temp-buffer)
+               (with-buffer-read-only buffer nil
+                 (erase-buffer buffer)
+                 (insert-buffer (buffer-point buffer) temp-buffer))
                (with-pop-up-typeout-window (stream buffer)
                  (declare (ignore stream)))))))
 


### PR DESCRIPTION
scheme-mode で autodoc の表示ができなくなっていたため修正しました。
(lisp-mode を参考にしました)

(一応、設定で右上表示にすることも可能にしてみましたが、
REPL だと初期段階でかぶってしまうので微妙でした。。。)
