### PR TITLE
Fix popup window position v2

### DIFF
--- a/lib/core/command.lisp
+++ b/lib/core/command.lisp
@@ -280,9 +280,13 @@
             (funcall move-to-column-fn (current-point) (get-next-line-context-column)))
     (cond ((plusp n)
            (move-to-end-of-buffer)
+           ;; to fix popup window position
+           (window-recenter (current-window))
            (editor-error "End of buffer"))
           ((minusp n)
            (move-to-beginning-of-buffer)
+           ;; to fix popup window position
+           (window-recenter (current-window))
            (editor-error "Beginning of buffer")))))
 
 (define-command next-line (&optional n) ("p")

--- a/lib/core/popup-window.lisp
+++ b/lib/core/popup-window.lisp
@@ -38,9 +38,12 @@
                       +min-height+))
          (x (+ (window-x source-window)
                (window-cursor-x source-window)))
-         (y (+ (window-y source-window)
-               (window-cursor-y source-window)
-               1))
+         (y (alexandria:clamp
+             (+ (window-y source-window)
+                (window-cursor-y source-window)
+                1)
+             0
+             (1- (display-height))))
          (w (max (+ width *extra-width-margin*)
                  +min-width+))
          (h (max height


### PR DESCRIPTION
- C-v (next-page) でファイル末尾に到達すると、画面最下部をはみ出して
  ポップアップ画面 (「End of buffer」) を表示することがあったため、
  修正しました。

- 原因は、next-page の処理で、
  (A) バッファのポインタ (カーソル位置) を 一画面分移動してから、
  (B) window-recenter でカーソルが画面の中心に来るように表示する
  処理になっているのですが、
  ファイル末尾に到達した場合には、
  (A) と (B) の間で ポップアップ画面 (「End of buffer」) の表示を行っていたため、
  画面最下部をはみ出して表示することになりました。

- 修正点は、「End of buffer」の表示前に、window-recenter を行うようにしたことと、
  念のため、popup-window.lisp の compute-cursor-position で、
  ポップアップ画面のY座標の範囲を制限するようにしたことです。

＜関連プルリクエスト＞
#525
