### PR TITLE
[lem-pdcurses] Adjust for Windows Terminal

### DIFF
--- a/frontends/pdcurses/ncurses-pdcurseswin32.lisp
+++ b/frontends/pdcurses/ncurses-pdcurseswin32.lisp
@@ -61,7 +61,6 @@
 ;; windows terminal type
 ;;   :mintty  : mintty  (winpty is needed)
 ;;   :conemu  : ConEmu  (experimental)
-;;               ('chcp 65001' must be done before run)
 ;;   :winterm : Windows Terminal (windows 10) (experimental)
 ;;   :cmd.exe : cmd.exe (experimental)
 (defvar *windows-term-type*


### PR DESCRIPTION
lem-pdcurses を、Windows Terminal 上で動かして少し調整しました。

Windows Terminal 上での実行方法は、以下に簡単に記述しておきました。
https://gist.github.com/Hamayama/fc442e71304629527866f7c69c2e9f5e

PDCurses-win10-jp に、VT エスケープシーケンスの処理を追加したため、
Windows Terminal でもマウスで操作できるようになりました。
(カーソルの移動、分割線のドラッグ、ホイールによるスクロールに対応)
