### PR TITLE
[scheme-mode] Fix autodoc display v2

### DIFF
--- a/modes/scheme-mode/scheme-mode.lisp
+++ b/modes/scheme-mode/scheme-mode.lisp
@@ -33,6 +33,9 @@
 (define-key *scheme-mode-keymap* "C-c C-c" 'scheme-compile-define)
 (define-key *scheme-mode-keymap* "C-c Return" 'scheme-macroexpand)
 (define-key *scheme-mode-keymap* "C-c M-m" 'scheme-macroexpand-all)
+(define-key *scheme-mode-keymap* "Space" 'scheme-insert-space-and-autodoc)
+(define-key *scheme-mode-keymap* "M-a" 'scheme-autodoc)
+;;(define-key *scheme-mode-keymap* "C-c C-d C-a" 'scheme-autodoc)
 (define-key *scheme-mode-keymap* "C-c C-d C-a" 'scheme-autodoc-with-typeout)
 (define-key *scheme-mode-keymap* "C-c C-d d" 'scheme-describe-symbol)
 (define-key *scheme-mode-keymap* "C-c C-z" 'scheme-switch-to-repl-buffer)
@@ -71,8 +74,9 @@
 ;;    :repl : use 'scheme-set-library' command for only repl
 ;;    nil   : disable 'scheme-set-library' command
 ;;  *use-scheme-autodoc*
-;;    t     : display function information in minibuffer
-;;    nil   : don't display function information in minibuffer
+;;    t     : display function information in popup window when space key is input
+;;    :auto : display function information in popup window automatically
+;;    nil   : don't display function information
 (defvar *use-scheme-slime* :auto)
 (defvar *use-scheme-set-library* :repl)
 (defvar *use-scheme-autodoc* t)

--- a/modes/scheme-mode/swank-connection.lisp
+++ b/modes/scheme-mode/swank-connection.lisp
@@ -320,6 +320,7 @@
   (check-connection)
   (interactive-eval string))
 
+;;(define-command scheme-eval-defun () ()
 (define-command scheme-eval-define () ()
   (check-connection)
   (with-point ((point (current-point)))
@@ -371,9 +372,8 @@
       (scheme-eval-async
        `(,autodoc-symbol ',context)
        (lambda (doc)
-         (ignore-errors
-          (destructuring-bind (doc cache-p) doc
-            (declare (ignore cache-p))
+         (trivia:match doc
+           ((list doc _)
             (unless (eq doc :not-available)
               (let* ((buffer (make-buffer "*swank:autodoc-fontity*"
                                           :temporary t :enable-undo-p nil))
@@ -390,20 +390,28 @@
                       (search-forward point "<===")
                       (delete-between-points start point)
                       (insert-string point string :attribute 'region))))
+                (buffer-start (buffer-point buffer))
+                (setf (variable-value 'truncate-lines :buffer buffer) nil)
                 (funcall function buffer))))))))))
 
 (define-command scheme-autodoc-with-typeout () ()
   (check-connection)
   (autodoc (lambda (temp-buffer)
              (let ((buffer (make-buffer (buffer-name temp-buffer))))
-               (erase-buffer buffer)
-               (insert-buffer (buffer-point buffer) temp-buffer)
+               (with-buffer-read-only buffer nil
+                 (erase-buffer buffer)
+                 (insert-buffer (buffer-point buffer) temp-buffer))
                (with-pop-up-typeout-window (stream buffer)
                  (declare (ignore stream)))))))
 
 (define-command scheme-autodoc () ()
   (check-connection)
   (autodoc (lambda (buffer) (message-buffer buffer))))
+
+(define-command scheme-insert-space-and-autodoc (n) ("p")
+  (loop :repeat n :do (insert-character (current-point) #\space))
+  (when (eq *use-scheme-autodoc* t)
+    (scheme-autodoc)))
 
 (defun check-parens ()
   (with-point ((point (current-point)))
@@ -519,6 +527,7 @@
                                                         nil)
                        #'compilation-finished)))
 
+;;(define-command scheme-compile-defun () ()
 (define-command scheme-compile-define () ()
   (check-connection)
   (with-point ((point (current-point)))
@@ -1119,10 +1128,10 @@
           ;           *use-scheme-set-library*
           ;           (not (eq *use-scheme-set-library* :repl)))
           ;  (update-buffer-package))
-          (when (and *use-scheme-autodoc*
-                     (member major-mode '(scheme-mode scheme-repl-mode)))
-            (unless (active-echoarea-p)
-              (scheme-autodoc))))
+          (when (and (eq *use-scheme-autodoc* :auto)
+                     (member major-mode '(scheme-mode scheme-repl-mode))
+                     (not (lem.popup-window::visible-popup-window-p)))
+            (scheme-autodoc)))
       (error () (scheme-slime-quit)))))
 
 (defun highlight-region (start end attribute name)


### PR DESCRIPTION
autodoc の動作を lisp-mode に合わせました。
(Space または M-a で autodoc を表示するようにしました)

＜関連プルリクエスト＞
#528
