### PR TITLE
Fix popup and prompt window display

### DIFF
--- a/frontends/ncurses/ncurses.lisp
+++ b/frontends/ncurses/ncurses.lisp
@@ -6,7 +6,16 @@
            :input-polling-interval))
 (in-package :lem-ncurses)
 
+;; escape key delay setting
 (define-editor-variable escape-delay 100)
+
+;; popup window margin setting
+(setf lem.popup-window::*extra-right-margin* 1)
+(setf lem.popup-window::*extra-width-margin* 0)
+
+;; prompt window margin setting
+(setf lem.prompt-window::*extra-width-margin* 2)
+
 
 (defclass ncurses (lem:implementation)
   ()

--- a/frontends/ncurses/ncurses.lisp
+++ b/frontends/ncurses/ncurses.lisp
@@ -14,7 +14,7 @@
 (setf lem.popup-window::*extra-width-margin* 0)
 
 ;; prompt window margin setting
-(setf lem.prompt-window::*extra-width-margin* 2)
+(setf lem.prompt-window::*extra-side-margin* 2)
 
 
 (defclass ncurses (lem:implementation)

--- a/frontends/pdcurses/ncurses-pdcurseswin32.lisp
+++ b/frontends/pdcurses/ncurses-pdcurseswin32.lisp
@@ -50,12 +50,16 @@
 ;;
 (setf (variable-value 'escape-delay :global) 1000)
 
-
 ;; popup window margin setting
 ;;  (extra margin is required to avoid partial loss of popup window display
 ;;   caused by wide characters)
 (setf lem.popup-window::*extra-right-margin* 1)
 (setf lem.popup-window::*extra-width-margin* 1)
+
+;; prompt window margin setting
+;;  (extra margin is required to avoid partial loss of popup window display
+;;   caused by wide characters)
+(setf lem.prompt-window::*extra-width-margin* 2)
 
 
 ;; windows terminal type

--- a/frontends/pdcurses/ncurses-pdcurseswin32.lisp
+++ b/frontends/pdcurses/ncurses-pdcurseswin32.lisp
@@ -59,7 +59,7 @@
 ;; prompt window margin setting
 ;;  (extra margin is required to avoid partial loss of popup window display
 ;;   caused by wide characters)
-(setf lem.prompt-window::*extra-width-margin* 2)
+(setf lem.prompt-window::*extra-side-margin* 2)
 
 
 ;; windows terminal type

--- a/lib/core/popup-window.lisp
+++ b/lib/core/popup-window.lisp
@@ -8,7 +8,6 @@
 (defparameter +min-width+   3)
 (defparameter +min-height+  1)
 
-;; for windows pdcurses
 (defvar *extra-right-margin* 0)
 (defvar *extra-width-margin* 0)
 
@@ -61,12 +60,11 @@
                       +min-height+))
          (x (+ (window-x source-window)
                (window-cursor-x source-window)))
-         (y (alexandria:clamp
-             (+ (window-y source-window)
-                (window-cursor-y source-window)
-                1)
-             0
-             (1- (display-height))))
+         (y (max (min (+ (window-y source-window)
+                         (window-cursor-y source-window)
+                         1)
+                      (1- (display-height)))
+                 0))
          (w width)
          (h height))
     ;; calc y and h

--- a/lib/core/prompt-window.lisp
+++ b/lib/core/prompt-window.lisp
@@ -10,7 +10,7 @@
 (defparameter +min-width+   3)
 (defparameter +min-height+  1)
 
-(defvar *extra-width-margin* 0)
+(defvar *extra-side-margin* 0)
 
 (defvar *history-table* (make-hash-table))
 
@@ -144,7 +144,7 @@
                  :maximize (+ (string-width string) 2))))
     (let* ((b2 (* +border-size+ 2))
            (width  (max (min (compute-width)
-                             (- (display-width)  b2 *extra-width-margin*))
+                             (- (display-width)  b2 *extra-side-margin*))
                         +min-width+))
            (height (max (min (buffer-nlines buffer)
                              (- (display-height) b2))

--- a/lib/core/prompt-window.lisp
+++ b/lib/core/prompt-window.lisp
@@ -6,6 +6,12 @@
   (:lock t))
 (in-package :lem.prompt-window)
 
+(defparameter +border-size+ 1)
+(defparameter +min-width+   3)
+(defparameter +min-height+  1)
+
+(defvar *extra-width-margin* 0)
+
 (defvar *history-table* (make-hash-table))
 
 (defvar *prompt-activate-hook* '())
@@ -38,7 +44,7 @@
   ((start-point
     :accessor prompt-window-start-charpos))
   (:default-initargs
-   :border 1))
+   :border +border-size+))
 
 (defclass prompt-buffer (buffer)
   ((prompt-string
@@ -135,9 +141,14 @@
 (defun compute-window-rectangle (buffer)
   (flet ((compute-width ()
            (loop :for string :in (uiop:split-string (buffer-text buffer) :separator '(#\newline))
-                 :maximize (+ 2 (string-width string)))))
-    (let* ((width (alexandria:clamp (compute-width) 3 (- (display-width) 3)))
-           (height (buffer-nlines buffer))
+                 :maximize (+ (string-width string) 2))))
+    (let* ((b2 (* +border-size+ 2))
+           (width  (max (min (compute-width)
+                             (- (display-width)  b2 *extra-width-margin*))
+                        +min-width+))
+           (height (max (min (buffer-nlines buffer)
+                             (- (display-height) b2))
+                        +min-height+))
            (x (- (floor (display-width) 2)
                  (floor width 2)))
            (y (- (floor (display-height) 2)


### PR DESCRIPTION
popup window と prompt window の表示の修正になります。

VirtualBox 上 の Linux Mint 20 で、動作確認したのですが、
画面の右端に border が表示されると、反転色が漏れ出すことがあるようでした。

このため、ncurses の場合も、`*extra-right-margin*` を設定するようにしました。

また、prompt window についても、popup window と同様の処理を行うようにしました。
これで #533 のコメントの件が直るのかは、ちょっと分かりませんが。。。
(そもそも、#533 では、prompt window の方は触ってない)

＜関連プルリクエスト＞
#525 #530 #533
